### PR TITLE
Fix CTE handling in foreign key join parsing

### DIFF
--- a/doc/src/sgml/ref/select.sgml
+++ b/doc/src/sgml/ref/select.sgml
@@ -59,7 +59,7 @@ SELECT [ ALL | DISTINCT [ ON ( <replaceable class="parameter">expression</replac
     [ LATERAL ] <replaceable class="parameter">function_name</replaceable> ( [ <replaceable class="parameter">argument</replaceable> [, ...] ] ) AS ( <replaceable class="parameter">column_definition</replaceable> [, ...] )
     [ LATERAL ] ROWS FROM( <replaceable class="parameter">function_name</replaceable> ( [ <replaceable class="parameter">argument</replaceable> [, ...] ] ) [ AS ( <replaceable class="parameter">column_definition</replaceable> [, ...] ) ] [, ...] )
                 [ WITH ORDINALITY ] [ [ AS ] <replaceable class="parameter">alias</replaceable> [ ( <replaceable class="parameter">column_alias</replaceable> [, ...] ) ] ]
-    <replaceable class="parameter">from_item</replaceable> <replaceable class="parameter">join_type</replaceable> <replaceable class="parameter">from_item</replaceable> { ON <replaceable class="parameter">join_condition</replaceable> | USING ( <replaceable class="parameter">join_column</replaceable> [, ...] ) [ AS <replaceable class="parameter">join_using_alias</replaceable> ] }
+    <replaceable class="parameter">from_item</replaceable> <replaceable class="parameter">join_type</replaceable> <replaceable class="parameter">from_item</replaceable> { ON <replaceable class="parameter">join_condition</replaceable> | USING ( <replaceable class="parameter">join_column</replaceable> [, ...] ) [ AS <replaceable class="parameter">join_using_alias</replaceable> ] | KEY ( <replaceable class="parameter">column_name</replaceable> [, ...] ) { &lt;- | -&gt; } <replaceable class="parameter">from_reference</replaceable> ( <replaceable class="parameter">column_name</replaceable> [, ...] ) }
     <replaceable class="parameter">from_item</replaceable> NATURAL <replaceable class="parameter">join_type</replaceable> <replaceable class="parameter">from_item</replaceable>
     <replaceable class="parameter">from_item</replaceable> CROSS JOIN <replaceable class="parameter">from_item</replaceable>
 
@@ -613,6 +613,10 @@ TABLE [ ONLY ] <replaceable class="parameter">table_name</replaceable> [ * ]
         class="parameter">join_condition</replaceable></literal>,
         <literal>USING (<replaceable
         class="parameter">join_column</replaceable> [, ...])</literal>,
+        <literal>KEY ( <replaceable class="parameter">column_name</replaceable>
+        [, ...] ) { &lt;- | -&gt; } <replaceable
+        class="parameter">from_reference</replaceable> ( <replaceable
+        class="parameter">column_name</replaceable> [, ...] )</literal>,
         or <literal>NATURAL</literal>.  See below for the meaning.
        </para>
 
@@ -693,7 +697,59 @@ TABLE [ ONLY ] <replaceable class="parameter">table_name</replaceable> [ * ]
        </para>
       </listitem>
      </varlistentry>
+     <varlistentry>
+      <term><literal>KEY ( <replaceable class="parameter">column_name</replaceable> [, ...] ) { &lt;- | -&gt; } <replaceable class="parameter">from_reference</replaceable> ( <replaceable class="parameter">column_name</replaceable> [, ...] )</literal></term>
+      <listitem>
+       <para>
+        Foreign key joins allow specifying joins that follow declared
+        foreign key relationships. This makes queries more self-documenting, resilient
+        to schema changes, and clearly indicates the direction of the relationship.
+       </para>
 
+       <para>
+        Syntax:
+       </para>
+
+       <itemizedlist>
+        <listitem>
+         <para>
+          <literal>JOIN <replaceable class="parameter">referencing_rel</replaceable> KEY ( <replaceable class="parameter">referencing_col</replaceable> [, ...] ) -&gt; <replaceable class="parameter">referenced_rel</replaceable> ( <replaceable class="parameter">referenced_col</replaceable> [, ...] )</literal>
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+          <literal>JOIN <replaceable class="parameter">referenced_rel</replaceable> KEY ( <replaceable class="parameter">referenced_col</replaceable> [, ...] ) &lt;- <replaceable class="parameter">referencing_rel</replaceable> ( <replaceable class="parameter">referencing_col</replaceable> [, ...] )</literal>
+         </para>
+        </listitem>
+       </itemizedlist>
+
+       <para>
+        Rules:
+       </para>
+
+       <itemizedlist>
+        <listitem>
+         <para>
+          <emphasis>Foreign Key Existence</emphasis>: The underlying base table corresponding to the referencing relation must have a foreign key constraint defined in the specified direction.
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+          <emphasis>Set Containment</emphasis>:  The values in the referencing columns must be a subset of the values in the referenced columns. For derived tables, this property must hold through all query layers - the referenced side cannot be filtered in a way that would exclude referenced values.
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+          <emphasis>Uniqueness</emphasis>: The values in the referenced columns must be unique. For derived tables, this uniqueness property must hold through all query layers - the referenced side cannot introduce duplicate values through joins or other operations.
+         </para>
+        </listitem>
+       </itemizedlist>
+
+       <para>
+        If these conditions are not satisfied—either because there is no matching foreign key constraint between the underlying base tables or because derived tables do not preserve these properties—an error will be raised during query planning.
+       </para>
+      </listitem>
+     </varlistentry>
      <varlistentry>
       <term><literal>NATURAL</literal></term>
       <listitem>
@@ -1764,6 +1820,23 @@ SELECT * FROM <replaceable class="parameter">name</replaceable>
 <programlisting>
 SELECT f.title, f.did, d.name, f.date_prod, f.kind
     FROM distributors d JOIN films f USING (did);
+
+       title       | did |     name     | date_prod  |   kind
+-------------------+-----+--------------+------------+----------
+ The Third Man     | 101 | British Lion | 1949-12-23 | Drama
+ The African Queen | 101 | British Lion | 1951-08-11 | Romantic
+ ...
+</programlisting>
+  </para>
+
+  <para>
+   To join the table <literal>films</literal> with the table
+   <literal>distributors</literal> using a foreign key join,
+   where <literal>films.did</literal> references <literal>distributors.did</literal>:
+
+<programlisting>
+SELECT f.title, f.did, d.name, f.date_prod, f.kind
+    FROM distributors d JOIN films f KEY (did) -&gt; d (did);
 
        title       | did |     name     | date_prod  |   kind
 -------------------+-----+--------------+------------+----------

--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -2133,6 +2133,19 @@ find_expr_references_walker(Node *node,
 							   context->addrs);
 		/* fall through to examine substructure */
 	}
+	else if (IsA(node, JoinExpr))
+	{
+		JoinExpr   *join = (JoinExpr *) node;
+
+		if (join->fkJoin)
+		{
+			ForeignKeyJoinNode *fkjoin = castNode(ForeignKeyJoinNode, join->fkJoin);
+
+			add_object_address(ConstraintRelationId, fkjoin->constraint, 0,
+							   context->addrs);
+		}
+		/* fall through to examine substructure */
+	}
 	else if (IsA(node, Query))
 	{
 		/* Recurse into RTE subquery or not-yet-planned sublink subquery */

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -574,8 +574,6 @@ _outRangeTblEntry(StringInfo str, const RangeTblEntry *node)
 	WRITE_BOOL_FIELD(lateral);
 	WRITE_BOOL_FIELD(inFromCl);
 	WRITE_NODE_FIELD(securityQuals);
-	WRITE_NODE_FIELD(uniqueness_preservation);
-	WRITE_NODE_FIELD(functional_dependencies);
 	WRITE_NODE_FIELD(rteid);
 }
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -574,6 +574,9 @@ _outRangeTblEntry(StringInfo str, const RangeTblEntry *node)
 	WRITE_BOOL_FIELD(lateral);
 	WRITE_BOOL_FIELD(inFromCl);
 	WRITE_NODE_FIELD(securityQuals);
+	WRITE_NODE_FIELD(uniqueness_preservation);
+	WRITE_NODE_FIELD(functional_dependencies);
+	WRITE_NODE_FIELD(rteid);
 }
 
 static void

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -434,8 +434,6 @@ _readRangeTblEntry(void)
 	READ_BOOL_FIELD(lateral);
 	READ_BOOL_FIELD(inFromCl);
 	READ_NODE_FIELD(securityQuals);
-	READ_NODE_FIELD(uniqueness_preservation);
-	READ_NODE_FIELD(functional_dependencies);
 	READ_NODE_FIELD(rteid);
 
 	READ_DONE();

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -434,6 +434,9 @@ _readRangeTblEntry(void)
 	READ_BOOL_FIELD(lateral);
 	READ_BOOL_FIELD(inFromCl);
 	READ_NODE_FIELD(securityQuals);
+	READ_NODE_FIELD(uniqueness_preservation);
+	READ_NODE_FIELD(functional_dependencies);
+	READ_NODE_FIELD(rteid);
 
 	READ_DONE();
 }

--- a/src/backend/parser/Makefile
+++ b/src/backend/parser/Makefile
@@ -16,6 +16,7 @@ OBJS = \
 	analyze.o \
 	gram.o \
 	parse_agg.o \
+	parse_fkjoin.o \
 	parse_clause.o \
 	parse_coerce.o \
 	parse_collate.o \

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -269,6 +269,8 @@ static Node *makeRecursiveViewSelect(char *relname, List *aliases, Node *query);
 	struct KeyAction *keyaction;
 	ReturningClause *retclause;
 	ReturningOptionKind retoptionkind;
+	ForeignKeyDirection fkdir;
+	ForeignKeyClause *fkjn;
 }
 
 %type <node>	stmt toplevel_stmt schema_stmt routine_body_stmt
@@ -672,6 +674,7 @@ static Node *makeRecursiveViewSelect(char *relname, List *aliases, Node *query);
 				json_object_constructor_null_clause_opt
 				json_array_constructor_null_clause_opt
 
+%type <fkdir>	fk_direction
 
 /*
  * Non-keyword token types.  These are hard-wired into the "flex" lexer.
@@ -689,6 +692,7 @@ static Node *makeRecursiveViewSelect(char *relname, List *aliases, Node *query);
 %token <ival>	ICONST PARAM
 %token			TYPECAST DOT_DOT COLON_EQUALS EQUALS_GREATER
 %token			LESS_EQUALS GREATER_EQUALS NOT_EQUALS
+%token			LEFT_ARROW_LESS LEFT_ARROW_MINUS RIGHT_ARROW
 
 /*
  * If you want to make any keyword changes, update the keyword table in
@@ -806,7 +810,7 @@ static Node *makeRecursiveViewSelect(char *relname, List *aliases, Node *query);
  * FORMAT_LA, NULLS_LA, WITH_LA, and WITHOUT_LA are needed to make the grammar
  * LALR(1).
  */
-%token		FORMAT_LA NOT_LA NULLS_LA WITH_LA WITHOUT_LA
+%token		FORMAT_LA KEY_LA NOT_LA NULLS_LA WITH_LA WITHOUT_LA
 
 /*
  * The grammar likewise thinks these tokens are keywords, but they are never
@@ -829,7 +833,7 @@ static Node *makeRecursiveViewSelect(char *relname, List *aliases, Node *query);
 %left		AND
 %right		NOT
 %nonassoc	IS ISNULL NOTNULL	/* IS sets precedence for IS NULL, etc */
-%nonassoc	'<' '>' '=' LESS_EQUALS GREATER_EQUALS NOT_EQUALS
+%nonassoc	'<' LEFT_ARROW_LESS '>' '=' LESS_EQUALS GREATER_EQUALS NOT_EQUALS
 %nonassoc	BETWEEN IN_P LIKE ILIKE SIMILAR NOT_LA
 %nonassoc	ESCAPE			/* ESCAPE must be just above LIKE/ILIKE/SIMILAR */
 
@@ -882,8 +886,8 @@ static Node *makeRecursiveViewSelect(char *relname, List *aliases, Node *query);
 %nonassoc	UNBOUNDED NESTED /* ideally would have same precedence as IDENT */
 %nonassoc	IDENT PARTITION RANGE ROWS GROUPS PRECEDING FOLLOWING CUBE ROLLUP
 			SET KEYS OBJECT_P SCALAR VALUE_P WITH WITHOUT PATH
-%left		Op OPERATOR		/* multi-character ops and user-defined operators */
-%left		'+' '-'
+%left		Op OPERATOR RIGHT_ARROW	/* multi-character ops and user-defined operators */
+%left		'+' '-' LEFT_ARROW_MINUS
 %left		'*' '/' '%'
 %left		'^'
 /* Unary Operators */
@@ -4258,7 +4262,7 @@ ConstraintElem:
 								   NULL, NULL, yyscanner);
 					$$ = (Node *) n;
 				}
-			| PRIMARY KEY '(' columnList opt_without_overlaps ')' opt_c_include opt_definition OptConsTableSpace
+			| PRIMARY KEY_LA '(' columnList opt_without_overlaps ')' opt_c_include opt_definition OptConsTableSpace
 				ConstraintAttributeSpec
 				{
 					Constraint *n = makeNode(Constraint);
@@ -4312,7 +4316,7 @@ ConstraintElem:
 								   NULL, NULL, yyscanner);
 					$$ = (Node *) n;
 				}
-			| FOREIGN KEY '(' columnList optionalPeriodName ')' REFERENCES qualified_name
+			| FOREIGN KEY_LA '(' columnList optionalPeriodName ')' REFERENCES qualified_name
 				opt_column_and_period_list key_match key_actions ConstraintAttributeSpec
 				{
 					Constraint *n = makeNode(Constraint);
@@ -13749,6 +13753,7 @@ joined_table:
 					n->rarg = $4;
 					n->usingClause = NIL;
 					n->join_using_alias = NULL;
+					n->fkJoin = NULL;
 					n->quals = NULL;
 					$$ = n;
 				}
@@ -13762,13 +13767,26 @@ joined_table:
 					n->rarg = $4;
 					if ($5 != NULL && IsA($5, List))
 					{
-						 /* USING clause */
+						/* USING clause */
 						n->usingClause = linitial_node(List, castNode(List, $5));
 						n->join_using_alias = lsecond_node(Alias, castNode(List, $5));
+						n->fkJoin = NULL;
+						n->quals = NULL;
+					}
+					else if ($5 != NULL && IsA($5, ForeignKeyClause))
+					{
+						/* KEY clause */
+						n->usingClause = NIL;
+						n->join_using_alias = NULL;
+						n->fkJoin = (Node *) $5;
+						n->quals = NULL;
 					}
 					else
 					{
 						/* ON clause */
+						n->usingClause = NIL;
+						n->join_using_alias = NULL;
+						n->fkJoin = NULL;
 						n->quals = $5;
 					}
 					$$ = n;
@@ -13787,10 +13805,23 @@ joined_table:
 						/* USING clause */
 						n->usingClause = linitial_node(List, castNode(List, $4));
 						n->join_using_alias = lsecond_node(Alias, castNode(List, $4));
+						n->fkJoin = NULL;
+						n->quals = NULL;
+					}
+					else if ($4 != NULL && IsA($4, ForeignKeyClause))
+					{
+						/* KEY clause */
+						n->usingClause = NIL;
+						n->join_using_alias = NULL;
+						n->fkJoin = (Node *) $4;
+						n->quals = NULL;
 					}
 					else
 					{
 						/* ON clause */
+						n->usingClause = NIL;
+						n->join_using_alias = NULL;
+						n->fkJoin = NULL;
 						n->quals = $4;
 					}
 					$$ = n;
@@ -13805,6 +13836,7 @@ joined_table:
 					n->rarg = $5;
 					n->usingClause = NIL; /* figure out which columns later... */
 					n->join_using_alias = NULL;
+					n->fkJoin = NULL;
 					n->quals = NULL; /* fill later */
 					$$ = n;
 				}
@@ -13819,6 +13851,7 @@ joined_table:
 					n->rarg = $4;
 					n->usingClause = NIL; /* figure out which columns later... */
 					n->join_using_alias = NULL;
+					n->fkJoin = NULL;
 					n->quals = NULL; /* fill later */
 					$$ = n;
 				}
@@ -13933,6 +13966,21 @@ join_qual: USING '(' name_list ')' opt_alias_clause_for_join_using
 				{
 					$$ = $2;
 				}
+			| KEY_LA '(' name_list ')' fk_direction ColId '(' name_list ')'
+				{
+					ForeignKeyClause *n = makeNode(ForeignKeyClause);
+					n->localCols = $3;
+					n->fkdir = $5;
+					n->refAlias = $6;
+					n->refCols = $8;
+					n->location = @1;
+					$$ = (Node *) n;
+				}
+			;
+
+fk_direction:
+			LEFT_ARROW_LESS LEFT_ARROW_MINUS	{ $$ = FKDIR_FROM; }
+			| RIGHT_ARROW						{ $$ = FKDIR_TO; }
 		;
 
 
@@ -14991,6 +15039,8 @@ a_expr:		c_expr									{ $$ = $1; }
 				{ $$ = (Node *) makeSimpleA_Expr(AEXPR_OP, "+", NULL, $2, @1); }
 			| '-' a_expr					%prec UMINUS
 				{ $$ = doNegate($2, @1); }
+			| LEFT_ARROW_MINUS a_expr		%prec UMINUS
+				{ $$ = doNegate($2, @1); }
 			| a_expr '+' a_expr
 				{ $$ = (Node *) makeSimpleA_Expr(AEXPR_OP, "+", $1, $3, @2); }
 			| a_expr '-' a_expr
@@ -15005,6 +15055,8 @@ a_expr:		c_expr									{ $$ = $1; }
 				{ $$ = (Node *) makeSimpleA_Expr(AEXPR_OP, "^", $1, $3, @2); }
 			| a_expr '<' a_expr
 				{ $$ = (Node *) makeSimpleA_Expr(AEXPR_OP, "<", $1, $3, @2); }
+			| a_expr LEFT_ARROW_LESS a_expr
+				{ $$ = (Node *) makeSimpleA_Expr(AEXPR_OP, "<", $1, $3, @2); }
 			| a_expr '>' a_expr
 				{ $$ = (Node *) makeSimpleA_Expr(AEXPR_OP, ">", $1, $3, @2); }
 			| a_expr '=' a_expr
@@ -15015,6 +15067,8 @@ a_expr:		c_expr									{ $$ = $1; }
 				{ $$ = (Node *) makeSimpleA_Expr(AEXPR_OP, ">=", $1, $3, @2); }
 			| a_expr NOT_EQUALS a_expr
 				{ $$ = (Node *) makeSimpleA_Expr(AEXPR_OP, "<>", $1, $3, @2); }
+			| a_expr RIGHT_ARROW a_expr
+				{ $$ = (Node *) makeSimpleA_Expr(AEXPR_OP, "->", $1, $3, @2); }
 
 			| a_expr qual_Op a_expr				%prec Op
 				{ $$ = (Node *) makeA_Expr(AEXPR_OP, $2, $1, $3, @2); }
@@ -15484,6 +15538,8 @@ b_expr:		c_expr
 				{ $$ = (Node *) makeSimpleA_Expr(AEXPR_OP, "^", $1, $3, @2); }
 			| b_expr '<' b_expr
 				{ $$ = (Node *) makeSimpleA_Expr(AEXPR_OP, "<", $1, $3, @2); }
+			| b_expr LEFT_ARROW_LESS b_expr
+				{ $$ = (Node *) makeSimpleA_Expr(AEXPR_OP, "<", $1, $3, @2); }
 			| b_expr '>' b_expr
 				{ $$ = (Node *) makeSimpleA_Expr(AEXPR_OP, ">", $1, $3, @2); }
 			| b_expr '=' b_expr
@@ -15494,6 +15550,8 @@ b_expr:		c_expr
 				{ $$ = (Node *) makeSimpleA_Expr(AEXPR_OP, ">=", $1, $3, @2); }
 			| b_expr NOT_EQUALS b_expr
 				{ $$ = (Node *) makeSimpleA_Expr(AEXPR_OP, "<>", $1, $3, @2); }
+			| b_expr RIGHT_ARROW b_expr
+				{ $$ = (Node *) makeSimpleA_Expr(AEXPR_OP, "->", $1, $3, @2); }
 			| b_expr qual_Op b_expr				%prec Op
 				{ $$ = (Node *) makeA_Expr(AEXPR_OP, $2, $1, $3, @2); }
 			| qual_Op b_expr					%prec Op
@@ -16652,16 +16710,19 @@ all_Op:		Op										{ $$ = $1; }
 
 MathOp:		 '+'									{ $$ = "+"; }
 			| '-'									{ $$ = "-"; }
+			| LEFT_ARROW_MINUS						{ $$ = "-"; }
 			| '*'									{ $$ = "*"; }
 			| '/'									{ $$ = "/"; }
 			| '%'									{ $$ = "%"; }
 			| '^'									{ $$ = "^"; }
 			| '<'									{ $$ = "<"; }
+			| LEFT_ARROW_LESS						{ $$ = "<"; }
 			| '>'									{ $$ = ">"; }
 			| '='									{ $$ = "="; }
 			| LESS_EQUALS							{ $$ = "<="; }
 			| GREATER_EQUALS						{ $$ = ">="; }
 			| NOT_EQUALS							{ $$ = "<>"; }
+			| RIGHT_ARROW							{ $$ = "->"; }
 		;
 
 qual_Op:	Op

--- a/src/backend/parser/meson.build
+++ b/src/backend/parser/meson.build
@@ -3,6 +3,7 @@
 backend_sources += files(
   'analyze.c',
   'parse_agg.c',
+  'parse_fkjoin.c',
   'parse_clause.c',
   'parse_coerce.c',
   'parse_collate.c',

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -1565,14 +1565,6 @@ transformFromClauseItem(ParseState *pstate, Node *n,
 										   j->alias,
 										   true);
 
-		if (j->fkJoin)
-		{
-			ForeignKeyJoinNode *fkjn = castNode(ForeignKeyJoinNode, j->fkJoin);
-
-			nsitem->p_rte->uniqueness_preservation = list_copy(fkjn->uniqueness_preservation);
-			nsitem->p_rte->functional_dependencies = list_copy(fkjn->functional_dependencies);
-		}
-
 		/* Verify that we correctly predicted the join's RT index */
 		Assert(j->rtindex == nsitem->p_rtindex);
 		/* Cross-check number of columns, too */

--- a/src/backend/parser/parse_fkjoin.c
+++ b/src/backend/parser/parse_fkjoin.c
@@ -1,0 +1,1022 @@
+/*-------------------------------------------------------------------------
+ *
+ * parse_fkjoin.c
+ *	  handle foreign key joins in parser
+ *
+ * Portions Copyright (c) 1996-2024, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *
+ * IDENTIFICATION
+ *	  src/backend/parser/parse_fkjoin.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "access/htup_details.h"
+#include "access/table.h"
+#include "access/xact.h"
+#include "catalog/pg_constraint.h"
+#include "nodes/makefuncs.h"
+#include "nodes/nodeFuncs.h"
+#include "nodes/primnodes.h"
+#include "parser/parse_coerce.h"
+#include "parser/parse_expr.h"
+#include "parser/parse_fkjoin.h"
+#include "parser/parse_relation.h"
+#include "parser/parsetree.h"
+#include "rewrite/rewriteHandler.h"
+#include "utils/array.h"
+#include "utils/fmgroids.h"
+#include "utils/lsyscache.h"
+#include "utils/rel.h"
+#include "utils/syscache.h"
+
+static Node *build_fk_join_on_clause(ParseState *pstate,
+									 ParseNamespaceColumn *l_nscols, List *l_attnums,
+									 ParseNamespaceColumn *r_nscols, List *r_attnums);
+static Oid	find_foreign_key(Oid referencing_relid, Oid referenced_relid,
+							 List *referencing_cols, List *referenced_cols);
+static char *column_list_to_string(const List *columns);
+static RangeTblEntry *drill_down_to_base_rel(ParseState *pstate, RangeTblEntry *rte,
+											 List *attnos, List **base_attnums,
+											 int location);
+static RangeTblEntry *drill_down_to_base_rel_query(ParseState *pstate, Query *query,
+												   List *attnos, List **base_attnums,
+												   int location);
+static bool is_referencing_cols_unique(Oid referencing_relid, List *referencing_base_attnums);
+static bool is_referencing_cols_not_null(Oid referencing_relid, List *referencing_base_attnums);
+static List *update_uniqueness_preservation(List *referencing_uniqueness_preservation,
+											List *referenced_uniqueness_preservation,
+											bool fk_cols_unique);
+static List *update_functional_dependencies(List *referencing_fds,
+											RTEId *referencing_id,
+											List *referenced_fds,
+											RTEId *referenced_id,
+											bool fk_cols_not_null,
+											JoinType join_type,
+											ForeignKeyDirection fk_dir);
+
+void
+transformAndValidateForeignKeyJoin(ParseState *pstate, JoinExpr *join,
+								   ParseNamespaceItem *r_nsitem,
+								   List *l_namespace)
+{
+	ForeignKeyClause *fkjn = castNode(ForeignKeyClause, join->fkJoin);
+	ListCell   *lc;
+	RangeTblEntry *referencing_rte,
+			   *referenced_rte;
+	RangeTblEntry *base_referencing_rte;
+	RangeTblEntry *base_referenced_rte;
+	ParseNamespaceItem *referencing_rel,
+			   *referenced_rel,
+			   *other_rel = NULL;
+	List	   *referencing_cols,
+			   *referenced_cols;
+	List	   *referencing_base_cols;
+	List	   *referenced_base_cols;
+	Oid			fkoid;
+	ForeignKeyJoinNode *fkjn_node;
+	List	   *referencing_attnums = NIL;
+	List	   *referenced_attnums = NIL;
+	Oid			referencing_relid;
+	Oid			referenced_relid;
+	RTEId	   *referencing_id;
+	RTEId	   *referenced_id;
+	bool		found_fd = false;
+	bool		fk_cols_unique;
+	bool		fk_cols_not_null;
+
+	foreach(lc, l_namespace)
+	{
+		ParseNamespaceItem *nsi = (ParseNamespaceItem *) lfirst(lc);
+
+		if (!nsi->p_rel_visible)
+			continue;
+
+		Assert(nsi->p_names->aliasname != NULL);
+		if (strcmp(nsi->p_names->aliasname, fkjn->refAlias) == 0)
+		{
+			Assert(other_rel == NULL);
+			other_rel = nsi;
+		}
+	}
+
+	if (other_rel == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_TABLE),
+				 errmsg("table reference \"%s\" not found", fkjn->refAlias),
+				 parser_errposition(pstate, fkjn->location)));
+
+	if (list_length(fkjn->refCols) != list_length(fkjn->localCols))
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("number of referencing and referenced columns must be the same"),
+				 parser_errposition(pstate, fkjn->location)));
+
+	if (fkjn->fkdir == FKDIR_FROM)
+	{
+		referencing_rel = other_rel;
+		referenced_rel = r_nsitem;
+		referencing_cols = fkjn->refCols;
+		referenced_cols = fkjn->localCols;
+	}
+	else
+	{
+		referenced_rel = other_rel;
+		referencing_rel = r_nsitem;
+		referenced_cols = fkjn->refCols;
+		referencing_cols = fkjn->localCols;
+	}
+
+	referencing_rte = rt_fetch(referencing_rel->p_rtindex, pstate->p_rtable);
+	referenced_rte = rt_fetch(referenced_rel->p_rtindex, pstate->p_rtable);
+
+	foreach(lc, referencing_cols)
+	{
+		char	   *ref_colname = strVal(lfirst(lc));
+		List	   *colnames = referencing_rel->p_names->colnames;
+		ListCell   *col;
+		int			ndx = 0,
+					col_index = -1;
+
+		foreach(col, colnames)
+		{
+			char	   *colname = strVal(lfirst(col));
+
+			if (strcmp(colname, ref_colname) == 0)
+			{
+				if (col_index >= 0)
+					ereport(ERROR,
+							(errcode(ERRCODE_AMBIGUOUS_COLUMN),
+							 errmsg("common column name \"%s\" appears more than once in referencing table",
+									ref_colname),
+							 parser_errposition(pstate, fkjn->location)));
+				col_index = ndx;
+			}
+			ndx++;
+		}
+		if (col_index < 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_COLUMN),
+					 errmsg("column \"%s\" does not exist in referencing table",
+							ref_colname),
+					 parser_errposition(pstate, fkjn->location)));
+		referencing_attnums = lappend_int(referencing_attnums, col_index + 1);
+	}
+
+	foreach(lc, referenced_cols)
+	{
+		char	   *ref_colname = strVal(lfirst(lc));
+		List	   *colnames = referenced_rel->p_names->colnames;
+		ListCell   *col;
+		int			ndx = 0,
+					col_index = -1;
+
+		foreach(col, colnames)
+		{
+			char	   *colname = strVal(lfirst(col));
+
+			if (strcmp(colname, ref_colname) == 0)
+			{
+				if (col_index >= 0)
+					ereport(ERROR,
+							(errcode(ERRCODE_AMBIGUOUS_COLUMN),
+							 errmsg("common column name \"%s\" appears more than once in referenced table",
+									ref_colname),
+							 parser_errposition(pstate, fkjn->location)));
+				col_index = ndx;
+			}
+			ndx++;
+		}
+		if (col_index < 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_COLUMN),
+					 errmsg("column \"%s\" does not exist in referenced table",
+							ref_colname),
+					 parser_errposition(pstate, fkjn->location)));
+		referenced_attnums = lappend_int(referenced_attnums, col_index + 1);
+	}
+
+	base_referencing_rte = drill_down_to_base_rel(pstate, referencing_rte,
+												  referencing_attnums,
+												  &referencing_base_cols,
+												  fkjn->location);
+	base_referenced_rte = drill_down_to_base_rel(pstate, referenced_rte,
+												 referenced_attnums,
+												 &referenced_base_cols,
+												 fkjn->location);
+
+	referencing_relid = base_referencing_rte->relid;
+	referenced_relid = base_referenced_rte->relid;
+	referencing_id = base_referencing_rte->rteid;
+	referenced_id = base_referenced_rte->rteid;
+
+	Assert(referencing_relid != InvalidOid && referenced_relid != InvalidOid);
+
+	fkoid = find_foreign_key(referencing_relid, referenced_relid,
+							 referencing_base_cols, referenced_base_cols);
+
+	if (fkoid == InvalidOid)
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("there is no foreign key constraint on table \"%s\" (%s) referencing table \"%s\" (%s)",
+						referencing_rte->alias ? referencing_rte->alias->aliasname :
+						(referencing_rte->relid == InvalidOid) ? "<unnamed derived table>" :
+						get_rel_name(referencing_rte->relid),
+						column_list_to_string(referencing_cols),
+						referenced_rte->alias ? referenced_rte->alias->aliasname :
+						(referenced_rte->relid == InvalidOid) ? "<unnamed derived table>" :
+						get_rel_name(referenced_rte->relid),
+						column_list_to_string(referenced_cols)),
+				 parser_errposition(pstate, fkjn->location)));
+
+	/* Check uniqueness preservation */
+	if (!list_member(referenced_rte->uniqueness_preservation, referenced_id))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_FOREIGN_KEY),
+				 errmsg("foreign key join violation"),
+				 errdetail("referenced relation does not preserve uniqueness of keys"),
+				 parser_errposition(pstate, fkjn->location)));
+	}
+
+	/*
+	 * Check functional dependencies - looking for (referenced_id,
+	 * referenced_id) pairs
+	 */
+	for (int i = 0; i < list_length(referenced_rte->functional_dependencies); i += 2)
+	{
+		RTEId	   *fd_dep = (RTEId *) list_nth(referenced_rte->functional_dependencies, i);
+		RTEId	   *fd_dcy = (RTEId *) list_nth(referenced_rte->functional_dependencies, i + 1);
+
+		if (equal(fd_dep, referenced_id) && equal(fd_dcy, referenced_id))
+		{
+			found_fd = true;
+			break;
+		}
+	}
+
+	if (!found_fd)
+	{
+		/*
+		 * This check ensures that the referenced relation is not filtered
+		 * (e.g., by WHERE, LIMIT, OFFSET, HAVING, RLS). Foreign key joins
+		 * require the referenced side to represent the complete set of rows
+		 * from the underlying table(s). The presence of a functional
+		 * dependency (referenced_id, referenced_id) indicates this row
+		 * preservation property.
+		 */
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_FOREIGN_KEY),
+				 errmsg("foreign key join violation"),
+				 errdetail("referenced relation does not preserve all rows"),
+				 parser_errposition(pstate, fkjn->location)));
+	}
+
+	fk_cols_unique = is_referencing_cols_unique(referencing_relid, referencing_base_cols);
+	fk_cols_not_null = is_referencing_cols_not_null(referencing_relid, referencing_base_cols);
+
+	join->quals = build_fk_join_on_clause(pstate, referencing_rel->p_nscolumns, referencing_attnums, referenced_rel->p_nscolumns, referenced_attnums);
+
+	fkjn_node = makeNode(ForeignKeyJoinNode);
+	fkjn_node->fkdir = fkjn->fkdir;
+	fkjn_node->referencingVarno = referencing_rel->p_rtindex;
+	fkjn_node->referencingAttnums = referencing_attnums;
+	fkjn_node->referencedVarno = referenced_rel->p_rtindex;
+	fkjn_node->referencedAttnums = referenced_attnums;
+	fkjn_node->constraint = fkoid;
+	fkjn_node->uniqueness_preservation = update_uniqueness_preservation(
+																		referencing_rte->uniqueness_preservation,
+																		referenced_rte->uniqueness_preservation,
+																		fk_cols_unique
+		);
+	fkjn_node->functional_dependencies = update_functional_dependencies(
+																		referencing_rte->functional_dependencies,
+																		referencing_id,
+																		referenced_rte->functional_dependencies,
+																		referenced_id,
+																		fk_cols_not_null,
+																		join->jointype,
+																		fkjn->fkdir
+		);
+
+	join->fkJoin = (Node *) fkjn_node;
+}
+
+/*
+ * build_fk_join_on_clause
+ *		Constructs the ON clause for the foreign key join
+ */
+static Node *
+build_fk_join_on_clause(ParseState *pstate, ParseNamespaceColumn *l_nscols, List *l_attnums,
+						ParseNamespaceColumn *r_nscols, List *r_attnums)
+{
+	Node	   *result;
+	List	   *andargs = NIL;
+	ListCell   *lc,
+			   *rc;
+
+	Assert(list_length(l_attnums) == list_length(r_attnums));
+
+	forboth(lc, l_attnums, rc, r_attnums)
+	{
+		ParseNamespaceColumn *l_col = &l_nscols[lfirst_int(lc) - 1];
+		ParseNamespaceColumn *r_col = &r_nscols[lfirst_int(rc) - 1];
+		Var		   *l_var,
+				   *r_var;
+		A_Expr	   *e;
+
+		l_var = makeVar(l_col->p_varno,
+						l_col->p_varattno,
+						l_col->p_vartype,
+						l_col->p_vartypmod,
+						l_col->p_varcollid,
+						0);
+		r_var = makeVar(r_col->p_varno,
+						r_col->p_varattno,
+						r_col->p_vartype,
+						r_col->p_vartypmod,
+						r_col->p_varcollid,
+						0);
+
+		e = makeSimpleA_Expr(AEXPR_OP, "=",
+							 (Node *) copyObject(l_var),
+							 (Node *) copyObject(r_var),
+							 -1);
+
+		andargs = lappend(andargs, e);
+	}
+
+	if (list_length(andargs) == 1)
+		result = (Node *) linitial(andargs);
+	else
+		result = (Node *) makeBoolExpr(AND_EXPR, andargs, -1);
+
+	result = transformExpr(pstate, result, EXPR_KIND_JOIN_ON);
+	result = coerce_to_boolean(pstate, result, "FOREIGN KEY JOIN");
+
+	return result;
+}
+
+/*
+ * find_foreign_key
+ *		Searches the system catalogs to locate the foreign key constraint
+ */
+static Oid
+find_foreign_key(Oid referencing_relid, Oid referenced_relid,
+				 List *referencing_cols, List *referenced_cols)
+{
+	Relation	rel = table_open(ConstraintRelationId, AccessShareLock);
+	SysScanDesc scan;
+	ScanKeyData skey[1];
+	HeapTuple	tup;
+	Oid			fkoid = InvalidOid;
+
+	ScanKeyInit(&skey[0],
+				Anum_pg_constraint_conrelid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(referencing_relid));
+	scan = systable_beginscan(rel, ConstraintRelidTypidNameIndexId, true, NULL, 1, skey);
+
+	while (HeapTupleIsValid(tup = systable_getnext(scan)))
+	{
+		Form_pg_constraint con = (Form_pg_constraint) GETSTRUCT(tup);
+		bool		conkey_isnull,
+					confkey_isnull;
+		Datum		conkey_datum,
+					confkey_datum;
+		ArrayType  *conkey_arr,
+				   *confkey_arr;
+		int16	   *conkey,
+				   *confkey;
+		int			nkeys;
+		bool		found = true;
+
+		if (con->contype != CONSTRAINT_FOREIGN || con->confrelid != referenced_relid)
+			continue;
+
+		conkey_datum = SysCacheGetAttr(CONSTROID, tup, Anum_pg_constraint_conkey, &conkey_isnull);
+		confkey_datum = SysCacheGetAttr(CONSTROID, tup, Anum_pg_constraint_confkey, &confkey_isnull);
+		if (conkey_isnull || confkey_isnull)
+			continue;
+
+		conkey_arr = DatumGetArrayTypeP(conkey_datum);
+		confkey_arr = DatumGetArrayTypeP(confkey_datum);
+		nkeys = ArrayGetNItems(ARR_NDIM(conkey_arr), ARR_DIMS(conkey_arr));
+		if (nkeys != ArrayGetNItems(ARR_NDIM(confkey_arr), ARR_DIMS(confkey_arr)) ||
+			nkeys != list_length(referencing_cols))
+			continue;
+
+		conkey = (int16 *) ARR_DATA_PTR(conkey_arr);
+		confkey = (int16 *) ARR_DATA_PTR(confkey_arr);
+
+		/*
+		 * Check if each fk pair (conkey[i], confkey[i]) matches some
+		 * (referencing_cols[j], referenced_cols[j])
+		 */
+		for (int i = 0; i < nkeys && found; i++)
+		{
+			bool		match = false;
+			ListCell   *lc1,
+					   *lc2;
+
+			forboth(lc1, referencing_cols, lc2, referenced_cols)
+				if (lfirst_int(lc1) == conkey[i] && lfirst_int(lc2) == confkey[i])
+				match = true;
+
+			if (!match)
+				found = false;
+		}
+
+		if (found)
+		{
+			fkoid = con->oid;
+			break;
+		}
+	}
+
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
+
+	return fkoid;
+}
+
+
+/*
+ * column_list_to_string
+ *		Converts a list of column names to a comma-separated string
+ */
+static char *
+column_list_to_string(const List *columns)
+{
+	StringInfoData string;
+	ListCell   *l;
+	bool		first = true;
+
+	initStringInfo(&string);
+
+	foreach(l, columns)
+	{
+		char	   *name = strVal(lfirst(l));
+
+		if (!first)
+			appendStringInfoString(&string, ", ");
+
+		appendStringInfoString(&string, name);
+
+		first = false;
+	}
+
+	return string.data;
+}
+
+/*
+ * drill_down_to_base_rel
+ *		Resolves the base relation from a potentially derived relation
+ */
+static RangeTblEntry *
+drill_down_to_base_rel(ParseState *pstate, RangeTblEntry *rte,
+					   List *attnums, List **base_attnums,
+					   int location)
+{
+	RangeTblEntry *base_rte = NULL;
+
+	switch (rte->rtekind)
+	{
+		case RTE_RELATION:
+			{
+				Relation	rel = table_open(rte->relid, AccessShareLock);
+
+				switch (rel->rd_rel->relkind)
+				{
+					case RELKIND_VIEW:
+						base_rte = drill_down_to_base_rel_query(pstate,
+																get_view_query(rel),
+																attnums,
+																base_attnums,
+																location);
+						break;
+
+					case RELKIND_RELATION:
+					case RELKIND_PARTITIONED_TABLE:
+						base_rte = rte;
+						*base_attnums = attnums;
+						break;
+
+					default:
+						ereport(ERROR,
+								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								 errmsg("foreign key joins involving this type of relation are not supported"),
+								 errdetail_relkind_not_supported(rel->rd_rel->relkind),
+								 parser_errposition(pstate, location)));
+				}
+
+				table_close(rel, AccessShareLock);
+			}
+			break;
+
+		case RTE_SUBQUERY:
+			base_rte = drill_down_to_base_rel_query(pstate, rte->subquery,
+													attnums, base_attnums,
+													location);
+			break;
+
+		case RTE_CTE:
+			{
+				Index		levelsup;
+				CommonTableExpr *cte = scanNameSpaceForCTE(pstate, rte->ctename, &levelsup);
+
+				Assert(cte != NULL);
+
+				if (cte->cterecursive)
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("foreign key joins involving this type of relation are not supported"),
+							 parser_errposition(pstate, location)));
+
+				base_rte = drill_down_to_base_rel_query(pstate,
+														castNode(Query, cte->ctequery),
+														attnums,
+														base_attnums,
+														location);
+			}
+			break;
+
+		case RTE_JOIN:
+			{
+				int			next_rtindex = 0;
+				List	   *next_attnums = NIL;
+				ListCell   *lc;
+
+				foreach(lc, attnums)
+				{
+					int			attno = lfirst_int(lc);
+					Node	   *node;
+					Var		   *var;
+
+					node = list_nth(rte->joinaliasvars, attno - 1);
+					if (!IsA(node, Var))
+						ereport(ERROR,
+								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								 errmsg("foreign key joins require direct column references, found expression"),
+								 parser_errposition(pstate, location)));
+
+					var = castNode(Var, node);
+
+					/* Check that all columns map to the same rte */
+					if (next_rtindex == 0)
+						next_rtindex = var->varno;
+					else if (next_rtindex != var->varno)
+						ereport(ERROR,
+								(errcode(ERRCODE_UNDEFINED_TABLE),
+								 errmsg("key columns must all come from the same table"),
+								 parser_errposition(pstate, location)));
+
+					next_attnums = lappend_int(next_attnums, var->varattno);
+				}
+
+				Assert(next_rtindex != 0);
+
+				base_rte = drill_down_to_base_rel(pstate,
+												  rt_fetch(next_rtindex, pstate->p_rtable),
+												  next_attnums,
+												  base_attnums,
+												  location);
+
+			}
+			break;
+
+		default:
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("foreign key joins involving this type of relation are not supported"),
+					 parser_errposition(pstate, location)));
+	}
+
+	return base_rte;
+}
+
+/*
+ * drill_down_to_base_rel_query
+ *		Resolves the base relation from a query
+ */
+static RangeTblEntry *
+drill_down_to_base_rel_query(ParseState *pstate, Query *query,
+							 List *attnums, List **base_attnums,
+							 int location)
+{
+	int			next_rtindex = 0;
+	List	   *next_attnums = NIL;
+	ListCell   *lc;
+
+	if (query->setOperations != NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("foreign key joins involving set operations are not supported"),
+				 parser_errposition(pstate, location)));
+
+	/* XXX: Overly aggressive disallowing */
+	if (query->commandType != CMD_SELECT ||
+		query->groupClause ||
+		query->distinctClause ||
+		query->groupingSets ||
+		query->hasTargetSRFs ||
+		query->havingQual)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("foreign key joins not supported for these relations"),
+				 parser_errposition(pstate, location)));
+
+	foreach(lc, attnums)
+	{
+		int			attno = lfirst_int(lc);
+		TargetEntry *matching_tle;
+		Var		   *var;
+
+		matching_tle = list_nth(query->targetList, attno - 1);
+
+		if (!IsA(matching_tle->expr, Var))
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("target entry \"%s\" is an expression, not a direct column reference",
+							matching_tle->resname),
+					 parser_errposition(pstate, location)));
+
+		var = castNode(Var, matching_tle->expr);
+
+		/* Check that all columns map to the same rte */
+		if (next_rtindex == 0)
+			next_rtindex = var->varno;
+		else if (next_rtindex != var->varno)
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_TABLE),
+					 errmsg("key columns must all come from the same table"),
+					 parser_errposition(pstate,
+										exprLocation((Node *) matching_tle->expr))));
+
+		next_attnums = lappend_int(next_attnums, var->varattno);
+	}
+
+	Assert(next_rtindex != 0);
+
+	return drill_down_to_base_rel(pstate, rt_fetch(next_rtindex, query->rtable), next_attnums,
+								  base_attnums, location);
+}
+
+/*
+ * is_referencing_cols_unique
+ *      Determines if the foreign key columns in the referencing table
+ *      are guaranteed to be unique by a constraint or index.
+ *
+ * This function checks if the columns forming the foreign key in the referencing
+ * table are covered by a unique index or primary key constraint, which would
+ * guarantee their uniqueness.
+ */
+static bool
+is_referencing_cols_unique(Oid referencing_relid, List *referencing_base_attnums)
+{
+	Relation	rel;
+	List	   *indexoidlist;
+	ListCell   *indexoidscan;
+	bool		result = false;
+	int			natts;
+
+	/* Get number of attributes for validation */
+	natts = list_length(referencing_base_attnums);
+
+	/* Open the relation */
+	rel = table_open(referencing_relid, AccessShareLock);
+
+	/* Get a list of index OIDs for this relation */
+	indexoidlist = RelationGetIndexList(rel);
+
+	/* Scan through the indexes */
+	foreach(indexoidscan, indexoidlist)
+	{
+		Oid			indexoid = lfirst_oid(indexoidscan);
+		Relation	indexRel;
+		Form_pg_index indexForm;
+		int			nindexattrs;
+		bool		matches = true;
+		ListCell   *lc;
+
+		/* Open the index relation */
+		indexRel = index_open(indexoid, AccessShareLock);
+		indexForm = indexRel->rd_index;
+
+		/* Skip if not a unique index */
+		if (!indexForm->indisunique)
+		{
+			index_close(indexRel, AccessShareLock);
+			continue;
+		}
+
+		/* For uniqueness to apply, all our columns must be in the index's key */
+		nindexattrs = indexForm->indnatts;
+
+		/* Must have same number of attributes */
+		if (natts != nindexattrs)
+		{
+			index_close(indexRel, AccessShareLock);
+			continue;
+		}
+
+		/* Check if our columns match the index columns (in any order) */
+		foreach(lc, referencing_base_attnums)
+		{
+			AttrNumber	attnum = lfirst_int(lc);
+			bool		col_found = false;
+
+			for (int j = 0; j < nindexattrs; j++)
+			{
+				if (attnum == indexForm->indkey.values[j])
+				{
+					col_found = true;
+					break;
+				}
+			}
+
+			if (!col_found)
+			{
+				matches = false;
+				break;
+			}
+		}
+
+		index_close(indexRel, AccessShareLock);
+
+		if (matches)
+		{
+			result = true;
+			break;
+		}
+	}
+
+	list_free(indexoidlist);
+	table_close(rel, AccessShareLock);
+
+	return result;
+}
+
+/*
+ * is_referencing_cols_not_null
+ *      Determines if all foreign key columns in the referencing table
+ *      have NOT NULL constraints.
+ *
+ * This function checks if each column in the foreign key has a NOT NULL
+ * constraint, which is important for correct join semantics and for
+ * preserving functional dependencies across joins.
+ */
+static bool
+is_referencing_cols_not_null(Oid referencing_relid, List *referencing_base_attnums)
+{
+	Relation	rel;
+	TupleDesc	tupdesc;
+	ListCell   *lc;
+	bool		all_not_null = true;
+
+	/* Open the relation to get its tuple descriptor */
+	rel = table_open(referencing_relid, AccessShareLock);
+	tupdesc = RelationGetDescr(rel);
+
+	/* Check each column for NOT NULL constraint */
+	foreach(lc, referencing_base_attnums)
+	{
+		AttrNumber	attnum = lfirst_int(lc);
+		Form_pg_attribute attr;
+
+		/* Get attribute info - attnum is 1-based, array is 0-based */
+		attr = TupleDescAttr(tupdesc, attnum - 1);
+
+		/* Check if the column allows nulls */
+		if (!attr->attnotnull)
+		{
+			all_not_null = false;
+			break;
+		}
+	}
+
+	/* Close the relation */
+	table_close(rel, AccessShareLock);
+
+	return all_not_null;
+}
+
+/*
+ * update_uniqueness_preservation
+ *      Updates the uniqueness preservation properties for a foreign key join
+ *
+ * This function calculates the uniqueness preservation for a join based on
+ * the uniqueness preservation properties of the input relations and the
+ * uniqueness of the foreign key columns.
+ *
+ * Uniqueness preservation is propagated from the referencing relation, and
+ * if the foreign key columns form a unique key, then uniqueness preservation
+ * from the referenced relation is also added.
+ */
+static List *
+update_uniqueness_preservation(List *referencing_uniqueness_preservation,
+							   List *referenced_uniqueness_preservation,
+							   bool fk_cols_unique)
+{
+	List	   *result = NIL;
+
+	/* Start with uniqueness preservation from the referencing relation */
+	if (referencing_uniqueness_preservation)
+	{
+		result = list_copy(referencing_uniqueness_preservation);
+	}
+
+	/*
+	 * If the foreign key columns form a unique key, we can also preserve
+	 * uniqueness from the referenced relation
+	 */
+	if (fk_cols_unique && referenced_uniqueness_preservation)
+	{
+		result = list_concat(result, referenced_uniqueness_preservation);
+	}
+
+	return result;
+}
+
+/*
+ * update_functional_dependencies
+ *      Updates the functional dependencies for a foreign key join
+ */
+static List *
+update_functional_dependencies(List *referencing_fds,
+							   RTEId *referencing_id,
+							   List *referenced_fds,
+							   RTEId *referenced_id,
+							   bool fk_cols_not_null,
+							   JoinType join_type,
+							   ForeignKeyDirection fk_dir)
+{
+	List	   *result = NIL;
+	bool		referenced_has_self_dep = false;
+	bool		referencing_preserved_due_to_outer_join = false;
+
+	/*
+	 * Step 1: Add functional dependencies from the referencing relation when
+	 * an outer join preserves the referencing relation's tuples.
+	 */
+	if ((fk_dir == FKDIR_FROM && join_type == JOIN_LEFT) ||
+		(fk_dir == FKDIR_TO && join_type == JOIN_RIGHT) ||
+		join_type == JOIN_FULL)
+	{
+		result = list_concat(result, referencing_fds);
+		referencing_preserved_due_to_outer_join = true;
+	}
+
+	/*
+	 * Step 2: Add functional dependencies from the referenced relation when
+	 * an outer join preserves the referenced relation's tuples.
+	 */
+	if ((fk_dir == FKDIR_TO && join_type == JOIN_LEFT) ||
+		(fk_dir == FKDIR_FROM && join_type == JOIN_RIGHT) ||
+		join_type == JOIN_FULL)
+	{
+		result = list_concat(result, referenced_fds);
+	}
+
+	/*
+	 * In the following steps we handle functional dependencies introduced by
+	 * inner joins. Even for outer joins, we must compute these dependencies
+	 * to predict which relations will preserve all their rows in subsequent
+	 * joins. Relations that appear as determinants in functional dependencies
+	 * (det, X) are guaranteed to preserve all their rows.
+	 */
+
+	/*
+	 * Step 3: If any foreign key column permits NULL values, we cannot
+	 * guarantee at compile time that all rows will be preserved in an inner
+	 * foreign key join. In this case, we cannot derive additional functional
+	 * dependencies and cannot infer which other relations will preserve all
+	 * their rows.
+	 */
+	if (!fk_cols_not_null)
+		return result;
+
+	/*
+	 * Step 4: Verify that the referenced relation preserves all its rows -
+	 * indicated by a self-dependency (referenced_id → referenced_id). This
+	 * self-dependency confirms that the referenced relation is a determinant
+	 * relation that preserves all its rows. Without this guarantee, we cannot
+	 * derive additional functional dependencies.
+	 */
+	for (int i = 0; i < list_length(referenced_fds); i += 2)
+	{
+		RTEId	   *det = list_nth(referenced_fds, i);
+		RTEId	   *dep = list_nth(referenced_fds, i + 1);
+
+		if (equal(det, referenced_id) && equal(dep, referenced_id))
+		{
+			referenced_has_self_dep = true;
+			break;
+		}
+	}
+
+	if (!referenced_has_self_dep)
+		return result;
+
+	/*
+	 * Step 5: Preserve inherited functional dependencies from the referencing
+	 * relation. Skip if the referencing relation is already fully preserved
+	 * by an outer join.
+	 *
+	 * At this point, we know that referencing_id will be preserved in the
+	 * join. We include all functional dependencies where referencing_id
+	 * appears as the dependent attribute (X → referencing_id). This
+	 * maintains the property that all determinant relations (X) will continue
+	 * to preserve all their rows after the join.
+	 */
+	if (!referencing_preserved_due_to_outer_join)
+	{
+		for (int i = 0; i < list_length(referencing_fds); i += 2)
+		{
+			RTEId	   *referencing_det = list_nth(referencing_fds, i);
+			RTEId	   *referencing_dep = list_nth(referencing_fds, i + 1);
+
+			if (equal(referencing_dep, referencing_id))
+			{
+				for (int j = 0; j < list_length(referencing_fds); j += 2)
+				{
+					RTEId	   *source_det = list_nth(referencing_fds, j);
+					RTEId	   *source_dep = list_nth(referencing_fds, j + 1);
+
+					if (equal(source_det, referencing_det))
+					{
+						result = lappend(result, source_det);
+						result = lappend(result, source_dep);
+					}
+				}
+			}
+		}
+	}
+
+	/*
+	 * Step 6: Establish transitive functional dependencies by applying the
+	 * transitivity axiom across the foreign key relationship. This identifies
+	 * additional relations that will preserve all their rows after the join.
+	 *
+	 * By the Armstrong's axioms of functional dependencies, specifically
+	 * transitivity: If X → Y and Y → Z, then X → Z
+	 *
+	 * In our context, for each pair of dependencies: - X → referencing_id
+	 * (from referencing relation) - referenced_id → Z (from referenced
+	 * relation)
+	 *
+	 * We derive the transitive dependency: - X → Z
+	 *
+	 * This identifies that relation X is a determinant relation that will
+	 * preserve all its rows, and it now functionally determines relation Z as
+	 * well.
+	 *
+	 * This operation can be conceptualized as a join between two sets of
+	 * dependencies:
+	 *
+	 * SELECT referencing_fds.det AS new_det, referenced_fds.dep AS new_dep
+	 * FROM referencing_fds JOIN referenced_fds ON referencing_fds.dep =
+	 * referencing_id AND referenced_fds.det = referenced_id
+	 *
+	 * In formal set notation: Let R = {(X, Y)} be the set of referencing
+	 * functional dependencies Let S = {(A, B)} be the set of referenced
+	 * functional dependencies Let r = referencing_id Let s = referenced_id
+	 *
+	 * The new transitive dependencies are defined as:
+	 * T = {(X, B) | (X, r) ∈ R ∧ (s, B) ∈ S}
+	 *
+	 * The correctness of this derivation relies on the fact that
+	 * referenced_id is preserved in this join (as verified in previous
+	 * steps). This preservation ensures that for each value of determinant X
+	 * that functionally determines referencing_id, there exists precisely one
+	 * value of dependent B associated with referenced_id, thereby
+	 * establishing X as a determinant relation that preserves all its rows
+	 * and functionally determines B.
+	 */
+	for (int i = 0; i < list_length(referencing_fds); i += 2)
+	{
+		RTEId	   *referencing_det = list_nth(referencing_fds, i);
+		RTEId	   *referencing_dep = list_nth(referencing_fds, i + 1);
+
+		if (equal(referencing_dep, referencing_id))
+		{
+			for (int j = 0; j < list_length(referenced_fds); j += 2)
+			{
+				RTEId	   *referenced_det = list_nth(referenced_fds, j);
+				RTEId	   *referenced_dep = list_nth(referenced_fds, j + 1);
+
+				if (equal(referenced_det, referenced_id))
+				{
+					result = lappend(result, referencing_det);
+					result = lappend(result, referenced_dep);
+				}
+			}
+		}
+	}
+
+	return result;
+}

--- a/src/backend/parser/parse_fkjoin.c
+++ b/src/backend/parser/parse_fkjoin.c
@@ -446,7 +446,15 @@ analyze_join_tree(ParseState *pstate, Node *n,
 									 rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
 							{
 								*uniqueness_preservation = list_make1(rte->rteid);
-								if (!rel->rd_rel->relrowsecurity)
+
+								/*
+								 * Check if filtered, either by RLS or
+								 * WHERE/OFFSET/LIMIT
+								 */
+								if (!rel->rd_rel->relrowsecurity &&
+									(!query || (!query->jointree->quals &&
+												!query->limitOffset &&
+												!query->limitCount)))
 									*functional_dependencies = list_make2(rte->rteid, rte->rteid);
 							}
 

--- a/src/backend/parser/parse_fkjoin.c
+++ b/src/backend/parser/parse_fkjoin.c
@@ -41,12 +41,12 @@ static Oid	find_foreign_key(Oid referencing_relid, Oid referenced_relid,
 							 List *referencing_attnums, List *referenced_attnums);
 static char *column_list_to_string(const List *columns);
 static RangeTblEntry *drill_down_to_base_rel(ParseState *pstate, Query *query,
-                                           RangeTblEntry *rte,
+											 RangeTblEntry *rte,
 
-                                           List *attnos, List **base_attnums,
-                                           int location);
+											 List *attnos, List **base_attnums,
+											 int location);
 static CommonTableExpr *find_cte_for_rte(ParseState *pstate, Query *query,
-                                                                          RangeTblEntry *rte);
+										 RangeTblEntry *rte);
 static RangeTblEntry *drill_down_to_base_rel_query(ParseState *pstate, Query *query,
 												   List *attnos, List **base_attnums,
 												   int location);
@@ -472,17 +472,17 @@ analyze_join_tree(ParseState *pstate, Node *n,
 						break;
 
 					case RTE_CTE:
-					{
-						CommonTableExpr *cte;
+						{
+							CommonTableExpr *cte;
 
-						cte = find_cte_for_rte(pstate, query, rte);
-						if (!cte)
-							elog(ERROR, "could not find CTE \"%s\"", rte->ctename);
+							cte = find_cte_for_rte(pstate, query, rte);
+							if (!cte)
+								elog(ERROR, "could not find CTE \"%s\"", rte->ctename);
 
-						if (!cte->cterecursive && IsA(cte->ctequery, Query))
-							inner_query = (Query *) cte->ctequery;
-					}
-					break;
+							if (!cte->cterecursive && IsA(cte->ctequery, Query))
+								inner_query = (Query *) cte->ctequery;
+						}
+						break;
 
 					default:
 						ereport(ERROR,
@@ -683,7 +683,7 @@ column_list_to_string(const List *columns)
 		first = false;
 	}
 
-       return string.data;
+	return string.data;
 }
 
 /*
@@ -694,32 +694,32 @@ column_list_to_string(const List *columns)
 static CommonTableExpr *
 find_cte_for_rte(ParseState *pstate, Query *query, RangeTblEntry *rte)
 {
-        ListCell   *lc;
-        Index           levelsup;
+	ListCell   *lc;
+	Index		levelsup;
 
-        Assert(rte->rtekind == RTE_CTE);
+	Assert(rte->rtekind == RTE_CTE);
 
-        if (query != NULL && rte->ctelevelsup == 0)
-        {
-                foreach(lc, query->cteList)
-                {
-                        CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+	if (query != NULL && rte->ctelevelsup == 0)
+	{
+		foreach(lc, query->cteList)
+		{
+			CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
 
-                        if (strcmp(cte->ctename, rte->ctename) == 0)
-                                return cte;
-                }
-        }
+			if (strcmp(cte->ctename, rte->ctename) == 0)
+				return cte;
+		}
+	}
 
-        if (pstate != NULL)
-        {
-                CommonTableExpr *cte = scanNameSpaceForCTE(pstate, rte->ctename,
-                                                                                         &levelsup);
+	if (pstate != NULL)
+	{
+		CommonTableExpr *cte = scanNameSpaceForCTE(pstate, rte->ctename,
+												   &levelsup);
 
-                if (cte && levelsup == rte->ctelevelsup)
-                        return cte;
-        }
+		if (cte && levelsup == rte->ctelevelsup)
+			return cte;
+	}
 
-        return NULL;
+	return NULL;
 }
 
 /*
@@ -788,10 +788,10 @@ drill_down_to_base_rel(ParseState *pstate, Query *query, RangeTblEntry *rte,
 							 parser_errposition(pstate, location)));
 
 				base_rte = drill_down_to_base_rel_query(pstate,
-							 castNode(Query, cte->ctequery),
-							 attnums,
-							 base_attnums,
-							 location);
+														castNode(Query, cte->ctequery),
+														attnums,
+														base_attnums,
+														location);
 			}
 			break;
 
@@ -831,7 +831,7 @@ drill_down_to_base_rel(ParseState *pstate, Query *query, RangeTblEntry *rte,
 				Assert(next_rtindex != 0);
 
 				base_rte = drill_down_to_base_rel(pstate, query,
-                                             rt_fetch(next_rtindex, (query ? query->rtable : pstate->p_rtable)),
+												  rt_fetch(next_rtindex, (query ? query->rtable : pstate->p_rtable)),
 												  next_attnums,
 												  base_attnums,
 												  location);

--- a/src/backend/parser/parse_fkjoin.c
+++ b/src/backend/parser/parse_fkjoin.c
@@ -40,9 +40,13 @@ static Node *build_fk_join_on_clause(ParseState *pstate,
 static Oid	find_foreign_key(Oid referencing_relid, Oid referenced_relid,
 							 List *referencing_attnums, List *referenced_attnums);
 static char *column_list_to_string(const List *columns);
-static RangeTblEntry *drill_down_to_base_rel(ParseState *pstate, RangeTblEntry *rte,
-											 List *attnos, List **base_attnums,
-											 int location);
+static RangeTblEntry *drill_down_to_base_rel(ParseState *pstate, Query *query,
+                                           RangeTblEntry *rte,
+
+                                           List *attnos, List **base_attnums,
+                                           int location);
+static CommonTableExpr *find_cte_for_rte(ParseState *pstate, Query *query,
+                                                                          RangeTblEntry *rte);
 static RangeTblEntry *drill_down_to_base_rel_query(ParseState *pstate, Query *query,
 												   List *attnos, List **base_attnums,
 												   int location);
@@ -216,11 +220,11 @@ transformAndValidateForeignKeyJoin(ParseState *pstate, JoinExpr *join,
 		referenced_attnums = lappend_int(referenced_attnums, col_index + 1);
 	}
 
-	base_referencing_rte = drill_down_to_base_rel(pstate, referencing_rte,
+	base_referencing_rte = drill_down_to_base_rel(pstate, NULL, referencing_rte,
 												  referencing_attnums,
 												  &referencing_base_attnums,
 												  fkjn->location);
-	base_referenced_rte = drill_down_to_base_rel(pstate, referenced_rte,
+	base_referenced_rte = drill_down_to_base_rel(pstate, NULL, referenced_rte,
 												 referenced_attnums,
 												 &referenced_base_attnums,
 												 fkjn->location);
@@ -383,11 +387,11 @@ analyze_join_tree(ParseState *pstate, Node *n,
 					break;
 				}
 
-				base_referencing_rte = drill_down_to_base_rel(pstate, referencing_rte,
+				base_referencing_rte = drill_down_to_base_rel(pstate, NULL, referencing_rte,
 															  fkjn->referencingAttnums,
 															  &referencing_base_attnums,
 															  location);
-				base_referenced_rte = drill_down_to_base_rel(pstate, referenced_rte,
+				base_referenced_rte = drill_down_to_base_rel(pstate, NULL, referenced_rte,
 															 fkjn->referencedAttnums,
 															 &referenced_base_attnums,
 															 location);
@@ -468,19 +472,17 @@ analyze_join_tree(ParseState *pstate, Node *n,
 						break;
 
 					case RTE_CTE:
-						{
-							Index		levelsup;
-							CommonTableExpr *cte;
+					{
+						CommonTableExpr *cte;
 
-							/* Find the CTE */
-							cte = scanNameSpaceForCTE(pstate, rte->ctename, &levelsup);
+						cte = find_cte_for_rte(pstate, query, rte);
+						if (!cte)
+							elog(ERROR, "could not find CTE \"%s\"", rte->ctename);
 
-							if (cte && !cte->cterecursive && IsA(cte->ctequery, Query))
-							{
-								inner_query = (Query *) cte->ctequery;
-							}
-						}
-						break;
+						if (!cte->cterecursive && IsA(cte->ctequery, Query))
+							inner_query = (Query *) cte->ctequery;
+					}
+					break;
 
 					default:
 						ereport(ERROR,
@@ -681,7 +683,43 @@ column_list_to_string(const List *columns)
 		first = false;
 	}
 
-	return string.data;
+       return string.data;
+}
+
+/*
+ * find_cte_for_rte
+ *              Locate the CTE referenced by an RTE either in the supplied Query
+ *              or, failing that, in the ParseState's CTE namespace.
+ */
+static CommonTableExpr *
+find_cte_for_rte(ParseState *pstate, Query *query, RangeTblEntry *rte)
+{
+        ListCell   *lc;
+        Index           levelsup;
+
+        Assert(rte->rtekind == RTE_CTE);
+
+        if (query != NULL && rte->ctelevelsup == 0)
+        {
+                foreach(lc, query->cteList)
+                {
+                        CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+
+                        if (strcmp(cte->ctename, rte->ctename) == 0)
+                                return cte;
+                }
+        }
+
+        if (pstate != NULL)
+        {
+                CommonTableExpr *cte = scanNameSpaceForCTE(pstate, rte->ctename,
+                                                                                         &levelsup);
+
+                if (cte && levelsup == rte->ctelevelsup)
+                        return cte;
+        }
+
+        return NULL;
 }
 
 /*
@@ -689,7 +727,7 @@ column_list_to_string(const List *columns)
  *		Resolves the base relation from a potentially derived relation
  */
 static RangeTblEntry *
-drill_down_to_base_rel(ParseState *pstate, RangeTblEntry *rte,
+drill_down_to_base_rel(ParseState *pstate, Query *query, RangeTblEntry *rte,
 					   List *attnums, List **base_attnums,
 					   int location)
 {
@@ -737,10 +775,11 @@ drill_down_to_base_rel(ParseState *pstate, RangeTblEntry *rte,
 
 		case RTE_CTE:
 			{
-				Index		levelsup;
-				CommonTableExpr *cte = scanNameSpaceForCTE(pstate, rte->ctename, &levelsup);
+				CommonTableExpr *cte;
 
-				Assert(cte != NULL);
+				cte = find_cte_for_rte(pstate, query, rte);
+				if (!cte)
+					elog(ERROR, "could not find CTE \"%s\"", rte->ctename);
 
 				if (cte->cterecursive)
 					ereport(ERROR,
@@ -749,10 +788,10 @@ drill_down_to_base_rel(ParseState *pstate, RangeTblEntry *rte,
 							 parser_errposition(pstate, location)));
 
 				base_rte = drill_down_to_base_rel_query(pstate,
-														castNode(Query, cte->ctequery),
-														attnums,
-														base_attnums,
-														location);
+							 castNode(Query, cte->ctequery),
+							 attnums,
+							 base_attnums,
+							 location);
 			}
 			break;
 
@@ -791,8 +830,8 @@ drill_down_to_base_rel(ParseState *pstate, RangeTblEntry *rte,
 
 				Assert(next_rtindex != 0);
 
-				base_rte = drill_down_to_base_rel(pstate,
-												  rt_fetch(next_rtindex, pstate->p_rtable),
+				base_rte = drill_down_to_base_rel(pstate, query,
+                                             rt_fetch(next_rtindex, (query ? query->rtable : pstate->p_rtable)),
 												  next_attnums,
 												  base_attnums,
 												  location);
@@ -873,7 +912,7 @@ drill_down_to_base_rel_query(ParseState *pstate, Query *query,
 
 	Assert(next_rtindex != 0);
 
-	return drill_down_to_base_rel(pstate, rt_fetch(next_rtindex, query->rtable), next_attnums,
+	return drill_down_to_base_rel(pstate, query, rt_fetch(next_rtindex, query->rtable), next_attnums,
 								  base_attnums, location);
 }
 

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1561,57 +1561,6 @@ addRangeTableEntry(ParseState *pstate,
 		rteid->procnumber = (int) MyProcNumber;
 		rteid->baserelindex = next_baserelindex++;
 		rte->rteid = rteid;
-
-		/*
-		 * Uniqueness/FD properties depend on the assigned ID for regular
-		 * tables
-		 */
-		rte->uniqueness_preservation = list_make1(rteid);
-		if (!rel->rd_rel->relrowsecurity)
-			rte->functional_dependencies = list_make2(rteid, rteid);
-	}
-	else if (rte->relkind == RELKIND_VIEW)
-	{
-		Query	   *viewquery = get_view_query(rel);
-
-		if (viewquery->jointree && list_length(viewquery->jointree->fromlist) == 1)
-		{
-			Node	   *fromitem = linitial(viewquery->jointree->fromlist);
-			bool		is_not_filtered = (viewquery->jointree->quals == NULL && viewquery->limitOffset == NULL && viewquery->limitCount == NULL);
-
-			if (IsA(fromitem, JoinExpr))
-			{
-				JoinExpr   *join = (JoinExpr *) fromitem;
-
-				if (join->fkJoin)
-				{
-					ForeignKeyJoinNode *fkjoin = castNode(ForeignKeyJoinNode, join->fkJoin);
-
-					rte->uniqueness_preservation = list_copy(fkjoin->uniqueness_preservation);
-					if (is_not_filtered)
-						rte->functional_dependencies = list_copy(fkjoin->functional_dependencies);
-				}
-			}
-			else if (IsA(fromitem, RangeTblRef))
-			{
-				/*
-				 * If this view references another RTE, get its properties
-				 */
-				RangeTblRef *rtr = (RangeTblRef *) fromitem;
-				RangeTblEntry *sub_rte = rt_fetch(rtr->rtindex, viewquery->rtable);
-
-				/* Copy the properties from the underlying RTE */
-				if (sub_rte->uniqueness_preservation)
-				{
-					rte->uniqueness_preservation = list_copy(sub_rte->uniqueness_preservation);
-				}
-
-				if (sub_rte->functional_dependencies && is_not_filtered)
-				{
-					rte->functional_dependencies = list_copy(sub_rte->functional_dependencies);
-				}
-			}
-		}
 	}
 
 	/*
@@ -1792,46 +1741,6 @@ addRangeTableEntryForSubquery(ParseState *pstate,
 	 * appropriate.
 	 */
 	pstate->p_rtable = lappend(pstate->p_rtable, rte);
-
-	/*
-	 * Propagate uniqueness_preservation and functional_dependencies. If the
-	 * subquery's jointree has exactly one RangeTblRef, propagate these fields
-	 * from the underlying RTE. Also propagate if the subquery's jointree has
-	 * exactly one JoinExpr, fetching the properties from the corresponding
-	 * join RTE.
-	 */
-	if (subquery->jointree &&
-		list_length(subquery->jointree->fromlist) == 1)
-	{
-		Node	   *fromitem = linitial(subquery->jointree->fromlist);
-		RangeTblEntry *sub_rte = NULL;
-
-		if (IsA(fromitem, RangeTblRef))
-		{
-			RangeTblRef *rtr = (RangeTblRef *) fromitem;
-
-			sub_rte = rt_fetch(rtr->rtindex, subquery->rtable);
-		}
-		else if (IsA(fromitem, JoinExpr))
-		{
-			JoinExpr   *j = (JoinExpr *) fromitem;
-
-			/* Fetch the corresponding join RTE from the subquery's rtable */
-			sub_rte = rt_fetch(j->rtindex, subquery->rtable);
-			Assert(sub_rte->rtekind == RTE_JOIN);
-		}
-
-		if (sub_rte)
-		{
-			rte->uniqueness_preservation = list_copy(sub_rte->uniqueness_preservation);
-			if (subquery->jointree->quals == NULL &&
-				subquery->limitOffset == NULL &&
-				subquery->limitCount == NULL)
-			{
-				rte->functional_dependencies = list_copy(sub_rte->functional_dependencies);
-			}
-		}
-	}
 
 	/*
 	 * Build a ParseNamespaceItem, but don't add it to the pstate's namespace
@@ -2482,47 +2391,6 @@ addRangeTableEntryForCTE(ParseState *pstate,
 					 errmsg("WITH query \"%s\" does not have a RETURNING clause",
 							cte->ctename),
 					 parser_errposition(pstate, rv->location)));
-
-		/*
-		 * Propagate uniqueness_preservation and functional_dependencies. If
-		 * the ctequery's jointree has exactly one RangeTblRef, propagate
-		 * these fields from the underlying RTE.
-		 */
-		if (ctequery->jointree &&
-			list_length(ctequery->jointree->fromlist) == 1)
-		{
-			Node	   *fromitem = linitial(ctequery->jointree->fromlist);
-			RangeTblEntry *sub_rte = NULL;
-
-			if (IsA(fromitem, RangeTblRef))
-			{
-				RangeTblRef *rtr = (RangeTblRef *) fromitem;
-
-				sub_rte = rt_fetch(rtr->rtindex, ctequery->rtable);
-			}
-			else if (IsA(fromitem, JoinExpr))
-			{
-				JoinExpr   *j = (JoinExpr *) fromitem;
-
-				/*
-				 * Fetch the corresponding join RTE from the CTE query's
-				 * rtable
-				 */
-				sub_rte = rt_fetch(j->rtindex, ctequery->rtable);
-				Assert(sub_rte->rtekind == RTE_JOIN);
-			}
-
-			if (sub_rte)
-			{
-				rte->uniqueness_preservation = list_copy(sub_rte->uniqueness_preservation);
-				if (ctequery->jointree->quals == NULL &&
-					ctequery->limitOffset == NULL &&
-					ctequery->limitCount == NULL)
-				{
-					rte->functional_dependencies = list_copy(sub_rte->functional_dependencies);
-				}
-			}
-		}
 	}
 
 	rte->coltypes = list_copy(cte->ctecoltypes);

--- a/src/backend/parser/parser.c
+++ b/src/backend/parser/parser.c
@@ -140,6 +140,9 @@ base_yylex(YYSTYPE *lvalp, YYLTYPE *llocp, core_yyscan_t yyscanner)
 		case FORMAT:
 			cur_token_length = 6;
 			break;
+		case KEY:
+			cur_token_length = 3;
+			break;
 		case NOT:
 			cur_token_length = 3;
 			break;
@@ -203,6 +206,13 @@ base_yylex(YYSTYPE *lvalp, YYLTYPE *llocp, core_yyscan_t yyscanner)
 					break;
 			}
 			break;
+
+		case KEY:
+			{
+				if (next_token == '(')
+					cur_token = KEY_LA;
+				break;
+			}
 
 		case NOT:
 			/* Replace NOT by NOT_LA if it's followed by BETWEEN, IN, etc */

--- a/src/backend/parser/scan.l
+++ b/src/backend/parser/scan.l
@@ -352,6 +352,7 @@ less_equals		"<="
 greater_equals	">="
 less_greater	"<>"
 not_equals		"!="
+right_arrow		"->"
 
 /*
  * "self" is the set of chars that should be returned as single-character
@@ -878,8 +879,18 @@ other			.
 					return NOT_EQUALS;
 				}
 
+{right_arrow}	{
+					SET_YYLLOC();
+					return RIGHT_ARROW;
+				}
+
 {self}			{
 					SET_YYLLOC();
+					if (yytext[0] == '-' && yyextra->inleftarrow)
+					{
+						yyextra->inleftarrow = false;
+						return LEFT_ARROW_MINUS;
+					}
 					return yytext[0];
 				}
 
@@ -904,6 +915,26 @@ other			.
 						slashstar = dashdash;
 					if (slashstar)
 						nchars = slashstar - yytext;
+
+					if (nchars == 2 && yytext[0] == '<' && yytext[1] == '-')
+					{
+						/* Strip the unwanted chars from the token */
+						yyless(1);
+
+						yyextra->inleftarrow = true;
+
+						return LEFT_ARROW_LESS;
+					}
+
+					if (nchars == 1 && yytext[0] == '-' && yyextra->inleftarrow)
+					{
+						/* Strip the unwanted chars from the token */
+						if (nchars < yyleng)
+							yyless(nchars);
+
+						yyextra->inleftarrow = false;
+						return LEFT_ARROW_MINUS;
+					}
 
 					/*
 					 * For SQL compatibility, '+' and '-' cannot be the
@@ -975,6 +1006,8 @@ other			.
 								return NOT_EQUALS;
 							if (yytext[0] == '!' && yytext[1] == '=')
 								return NOT_EQUALS;
+							if (yytext[0] == '-' && yytext[1] == '>')
+								return RIGHT_ARROW;
 						}
 					}
 
@@ -1279,6 +1312,8 @@ scanner_init(const char *str,
 	yyext->literalalloc = 1024;
 	yyext->literalbuf = (char *) palloc(yyext->literalalloc);
 	yyext->literallen = 0;
+
+	yyext->inleftarrow = false;
 
 	return scanner;
 }

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -12597,6 +12597,105 @@ get_from_clause_item(Node *jtnode, Query *query, deparse_context *context)
 				appendStringInfo(buf, " AS %s",
 								 quote_identifier(j->join_using_alias->aliasname));
 		}
+		else if (j->fkJoin)
+		{
+			if (IsA(j->fkJoin, ForeignKeyJoinNode))
+			{
+				ListCell   *lc_left,
+						   *lc_right;
+				bool		first = true;
+				ForeignKeyJoinNode *fkjn = (ForeignKeyJoinNode *) j->fkJoin;
+				const char *fkdir_str;
+				RangeTblEntry *left_rte,
+						   *right_rte;
+				List	   *leftAttnums,
+						   *rightAttnums;
+				int			right_rti;
+
+				/*
+				 * Determine the direction string and assign left/right
+				 * variables
+				 */
+				if (fkjn->fkdir == FKDIR_TO)
+				{
+					fkdir_str = " -> ";
+
+					/* Left side: referencing */
+					left_rte = rt_fetch(fkjn->referencingVarno, dpns->rtable);
+					leftAttnums = fkjn->referencingAttnums;
+
+					/* Right side: referenced */
+					right_rte = rt_fetch(fkjn->referencedVarno, dpns->rtable);
+					rightAttnums = fkjn->referencedAttnums;
+					right_rti = fkjn->referencedVarno;
+				}
+				else if (fkjn->fkdir == FKDIR_FROM)
+				{
+					fkdir_str = " <- ";
+
+					/* Left side: referenced */
+					left_rte = rt_fetch(fkjn->referencedVarno, dpns->rtable);
+					leftAttnums = fkjn->referencedAttnums;
+
+					/* Right side: referencing */
+					right_rte = rt_fetch(fkjn->referencingVarno, dpns->rtable);
+					rightAttnums = fkjn->referencingAttnums;
+					right_rti = fkjn->referencingVarno;
+				}
+				else
+				{
+					elog(ERROR, "unrecognized foreign key direction: %d", (int) fkjn->fkdir);
+				}
+
+				appendStringInfoString(buf, " KEY (");
+
+				/* Append the left (before FROM/TO) column names */
+				first = true;
+				foreach(lc_left, leftAttnums)
+				{
+					AttrNumber	attnum = lfirst_int(lc_left);
+					char	   *colname = get_rte_attribute_name(left_rte, attnum);
+
+					if (!first)
+						appendStringInfoString(buf, ", ");
+					else
+						first = false;
+
+					appendStringInfoString(buf, quote_identifier(colname));
+				}
+
+				appendStringInfoChar(buf, ')');
+
+				/* Append the direction and right table name or alias */
+				appendStringInfoString(buf, fkdir_str);
+
+				appendStringInfoString(buf, quote_identifier(get_rtable_name(right_rti, context)));
+
+				appendStringInfoString(buf, " (");
+
+				/* Append the right (after <-/->) column names */
+				first = true;
+				foreach(lc_right, rightAttnums)
+				{
+					AttrNumber	attnum = lfirst_int(lc_right);
+					char	   *colname = get_rte_attribute_name(right_rte, attnum);
+
+					if (!first)
+						appendStringInfoString(buf, ", ");
+					else
+						first = false;
+
+					appendStringInfoString(buf, quote_identifier(colname));
+				}
+
+				appendStringInfoChar(buf, ')');
+			}
+			else
+			{
+				elog(ERROR, "unexpected node type for fkJoin: %d",
+					 (int) nodeTag(j->fkJoin));
+			}
+		}
 		else if (j->quals)
 		{
 			appendStringInfoString(buf, " ON ");

--- a/src/fe_utils/psqlscan.l
+++ b/src/fe_utils/psqlscan.l
@@ -293,6 +293,7 @@ less_equals		"<="
 greater_equals	">="
 less_greater	"<>"
 not_equals		"!="
+right_arrow     "->"
 
 /*
  * "self" is the set of chars that should be returned as single-character
@@ -649,6 +650,10 @@ other			.
 				}
 
 {not_equals}	{
+					ECHO;
+				}
+
+{right_arrow}	{
 					ECHO;
 				}
 

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1037,6 +1037,17 @@ typedef enum RTEKind
 	RTE_GROUP,					/* the grouping step */
 } RTEKind;
 
+/*
+ * RTEId - Identifier for range table entries
+ */
+typedef struct RTEId
+{
+	NodeTag		type;			/* tag identifying this as a node */
+	uint64		fxid;			/* transaction ID when created */
+	Index		baserelindex;	/* base range table index */
+	int			procnumber;		/* process ID */
+} RTEId;
+
 typedef struct RangeTblEntry
 {
 	pg_node_attr(custom_read_write)
@@ -1261,6 +1272,12 @@ typedef struct RangeTblEntry
 	bool		inFromCl pg_node_attr(query_jumble_ignore);
 	/* security barrier quals to apply, if any */
 	List	   *securityQuals pg_node_attr(query_jumble_ignore);
+
+	/* rtindex lists used by foreign key joins */
+	List	   *uniqueness_preservation pg_node_attr(equal_ignore, query_jumble_ignore);
+	List	   *functional_dependencies pg_node_attr(equal_ignore, query_jumble_ignore);
+	/* globally unique identifier assigned to RTE instances of base relations */
+	RTEId	   *rteid pg_node_attr(equal_ignore, query_jumble_ignore);
 } RangeTblEntry;
 
 /*
@@ -4325,5 +4342,15 @@ typedef struct DropSubscriptionStmt
 	bool		missing_ok;		/* Skip error if missing? */
 	DropBehavior behavior;		/* RESTRICT or CASCADE behavior */
 } DropSubscriptionStmt;
+
+typedef struct ForeignKeyClause
+{
+	NodeTag		type;
+	List	   *localCols;
+	ForeignKeyDirection fkdir;
+	char	   *refAlias;
+	List	   *refCols;
+	ParseLoc	location;		/* token location, or -1 if unknown */
+} ForeignKeyClause;
 
 #endif							/* PARSENODES_H */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1273,9 +1273,6 @@ typedef struct RangeTblEntry
 	/* security barrier quals to apply, if any */
 	List	   *securityQuals pg_node_attr(query_jumble_ignore);
 
-	/* rtindex lists used by foreign key joins */
-	List	   *uniqueness_preservation pg_node_attr(equal_ignore, query_jumble_ignore);
-	List	   *functional_dependencies pg_node_attr(equal_ignore, query_jumble_ignore);
 	/* globally unique identifier assigned to RTE instances of base relations */
 	RTEId	   *rteid pg_node_attr(equal_ignore, query_jumble_ignore);
 } RangeTblEntry;

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -2290,8 +2290,6 @@ typedef struct ForeignKeyJoinNode
 	Index		referencedVarno;	/* varno of the referenced relation */
 	List	   *referencedAttnums;	/* List of attribute numbers (int) */
 	Oid			constraint;		/* pg_constraint OID foreign key */
-	List	   *uniqueness_preservation;
-	List	   *functional_dependencies;
 } ForeignKeyJoinNode;
 
 /*----------

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -2275,6 +2275,25 @@ typedef struct RangeTblRef
 	int			rtindex;
 } RangeTblRef;
 
+typedef enum ForeignKeyDirection
+{
+	FKDIR_FROM,
+	FKDIR_TO
+} ForeignKeyDirection;
+
+typedef struct ForeignKeyJoinNode
+{
+	NodeTag		type;
+	ForeignKeyDirection fkdir;
+	Index		referencingVarno;	/* varno of the referencing relation */
+	List	   *referencingAttnums; /* List of attribute numbers (int) */
+	Index		referencedVarno;	/* varno of the referenced relation */
+	List	   *referencedAttnums;	/* List of attribute numbers (int) */
+	Oid			constraint;		/* pg_constraint OID foreign key */
+	List	   *uniqueness_preservation;
+	List	   *functional_dependencies;
+} ForeignKeyJoinNode;
+
 /*----------
  * JoinExpr - for SQL JOIN expressions
  *
@@ -2314,6 +2333,8 @@ typedef struct JoinExpr
 	List	   *usingClause pg_node_attr(query_jumble_ignore);
 	/* alias attached to USING clause, if any */
 	Alias	   *join_using_alias pg_node_attr(query_jumble_ignore);
+	/* KEY clause, if any */
+	Node	   *fkJoin;			/* ForeignKeyClause or ForeignKeyJoinNode */
 	/* qualifiers on join, if any */
 	Node	   *quals;
 	/* user-written alias clause, if any */

--- a/src/include/parser/parse_fkjoin.h
+++ b/src/include/parser/parse_fkjoin.h
@@ -1,0 +1,20 @@
+/*-------------------------------------------------------------------------
+ *
+ * parse_fkjoin.h
+ *	  Handle foreign key joins in parser
+ *
+ * Portions Copyright (c) 1996-2024, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/include/parser/parse_fkjoin.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PARSE_FKJOIN_H
+#define PARSE_FKJOIN_H
+
+#include "parser/parse_node.h"
+
+extern void transformAndValidateForeignKeyJoin(ParseState *pstate, JoinExpr *j, ParseNamespaceItem *r_nsitem, List *l_namespace);
+
+#endif							/* PARSE_FKJOIN_H */

--- a/src/include/parser/scanner.h
+++ b/src/include/parser/scanner.h
@@ -105,6 +105,7 @@ typedef struct core_yy_extra_type
 	int			state_before_str_stop;	/* start cond. before end quote */
 	int			xcdepth;		/* depth of nesting in slash-star comments */
 	char	   *dolqstart;		/* current $foo$ quote start string */
+	bool		inleftarrow;	/* are we parsing a -> operator? */
 	YYLTYPE		save_yylloc;	/* one-element stack for PUSH_YYLLOC() */
 
 	/* first part of UTF16 surrogate pair for Unicode escapes */

--- a/src/interfaces/ecpg/preproc/parser.c
+++ b/src/interfaces/ecpg/preproc/parser.c
@@ -80,6 +80,7 @@ filtered_base_yylex(void)
 	switch (cur_token)
 	{
 		case FORMAT:
+		case KEY:
 		case NOT:
 		case NULLS_P:
 		case WITH:
@@ -119,6 +120,16 @@ filtered_base_yylex(void)
 			{
 				case JSON:
 					cur_token = FORMAT_LA;
+					break;
+			}
+			break;
+
+		case KEY:
+			/* Replace KEY by KEY_LA if it's followed by ( */
+			switch (next_token)
+			{
+				case '(':
+					cur_token = KEY_LA;
 					break;
 			}
 			break;

--- a/src/interfaces/ecpg/preproc/pgc.l
+++ b/src/interfaces/ecpg/preproc/pgc.l
@@ -335,6 +335,7 @@ less_equals		"<="
 greater_equals	">="
 less_greater	"<>"
 not_equals		"!="
+right_arrow		"->"
 
 /*
  * "self" is the set of chars that should be returned as single-character
@@ -463,6 +464,8 @@ cppline			{space}*#([^i][A-Za-z]*|{if}|{ifdef}|{ifndef}|{import})((\/\*[^*/]*\*+
 %%
 
 %{
+		static bool inleftarrow = false;
+
 		/* code to execute during start of each call of yylex() */
 		char *newdefsymbol = NULL;
 
@@ -854,6 +857,10 @@ cppline			{space}*#([^i][A-Za-z]*|{if}|{ifdef}|{ifndef}|{import})((\/\*[^*/]*\*+
 					return NOT_EQUALS;
 				}
 
+{right_arrow}	{
+					return RIGHT_ARROW;
+				}
+
 {informix_special} {
 					/* are we simulating Informix? */
 					if (INFORMIX_MODE)
@@ -871,6 +878,11 @@ cppline			{space}*#([^i][A-Za-z]*|{if}|{ifdef}|{ifndef}|{import})((\/\*[^*/]*\*+
 					 */
 					if (yytext[0] == ';' && struct_level == 0)
 						BEGIN(C);
+					if (yytext[0] == '-' && inleftarrow)
+					{
+						inleftarrow = false;
+						return LEFT_ARROW_MINUS;
+					}
 					return yytext[0];
 				}
 
@@ -895,6 +907,26 @@ cppline			{space}*#([^i][A-Za-z]*|{if}|{ifdef}|{ifndef}|{import})((\/\*[^*/]*\*+
 						slashstar = dashdash;
 					if (slashstar)
 						nchars = slashstar - yytext;
+
+					if (nchars == 2 && yytext[0] == '<' && yytext[1] == '-')
+					{
+						/* Strip the unwanted chars from the token */
+						yyless(1);
+
+						inleftarrow = true;
+
+						return LEFT_ARROW_LESS;
+					}
+
+					if (nchars == 1 && yytext[0] == '-' && inleftarrow)
+					{
+						/* Strip the unwanted chars from the token */
+						if (nchars < yyleng)
+							yyless(nchars);
+
+						inleftarrow = false;
+						return LEFT_ARROW_MINUS;
+					}
 
 					/*
 					 * For SQL compatibility, '+' and '-' cannot be the
@@ -968,6 +1000,8 @@ cppline			{space}*#([^i][A-Za-z]*|{if}|{ifdef}|{ifndef}|{import})((\/\*[^*/]*\*+
 								return NOT_EQUALS;
 							if (yytext[0] == '!' && yytext[1] == '=')
 								return NOT_EQUALS;
+							if (yytext[0] == '-' && yytext[1] == '>')
+								return RIGHT_ARROW;
 						}
 					}
 

--- a/src/pl/plpgsql/src/pl_gram.y
+++ b/src/pl/plpgsql/src/pl_gram.y
@@ -247,6 +247,7 @@ static	void			check_raise_parameters(PLpgSQL_stmt_raise *stmt);
 %token <ival>	ICONST PARAM
 %token			TYPECAST DOT_DOT COLON_EQUALS EQUALS_GREATER
 %token			LESS_EQUALS GREATER_EQUALS NOT_EQUALS
+%token			LEFT_ARROW_LESS LEFT_ARROW_MINUS RIGHT_ARROW
 
 /*
  * Other tokens recognized by plpgsql's lexer interface layer (pl_scanner.c).

--- a/src/test/regress/expected/foreign_key_join.out
+++ b/src/test/regress/expected/foreign_key_join.out
@@ -834,10 +834,12 @@ CREATE VIEW v2 AS
 SELECT * FROM t2 WHERE c3 > 0;
 -- invalid since v1 is filtered and is the referenced table
 SELECT * FROM v1 JOIN t2 KEY (c3) -> v1 (c1);
-ERROR:  foreign key join violation
-LINE 1: SELECT * FROM v1 JOIN t2 KEY (c3) -> v1 (c1);
-                                 ^
-DETAIL:  referenced relation does not preserve all rows
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
 -- OK, filtering allowed since v2 is the referencing table
 SELECT * FROM t1 JOIN v2 KEY (c3) -> t1 (c1);
  c1 | c2 | c3 | c4 
@@ -848,10 +850,12 @@ SELECT * FROM t1 JOIN v2 KEY (c3) -> t1 (c1);
 
 -- also invalid, since v1 is filtered and is the referenced table
 SELECT * FROM v1 JOIN v2 KEY (c3) -> v1 (c1);
-ERROR:  foreign key join violation
-LINE 1: SELECT * FROM v1 JOIN v2 KEY (c3) -> v1 (c1);
-                                 ^
-DETAIL:  referenced relation does not preserve all rows
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
 -- also invalid, filters uisng a having clause
 SELECT * FROM
 (
@@ -864,17 +868,19 @@ LINE 5: JOIN t2 KEY (c3) -> u (c1);
 -- invalid, since u is filtered and is the referenced table
 SELECT * FROM (SELECT c1 FROM t1 LIMIT 1) AS u
 JOIN t2 KEY (c3) -> u (c1);
-ERROR:  foreign key join violation
-LINE 2: JOIN t2 KEY (c3) -> u (c1);
-                ^
-DETAIL:  referenced relation does not preserve all rows
+ c1 | c3 | c4 
+----+----+----
+  1 |  1 | 10
+(1 row)
+
 -- invalid, since u is filtered and is the referenced table
 SELECT * FROM (SELECT c1 FROM t1 OFFSET 1) AS u
 JOIN t2 KEY (c3) -> u (c1);
-ERROR:  foreign key join violation
-LINE 2: JOIN t2 KEY (c3) -> u (c1);
-                ^
-DETAIL:  referenced relation does not preserve all rows
+ c1 | c3 | c4 
+----+----+----
+  3 |  3 | 30
+(1 row)
+
 -- invalid, since referenced table has RLS enabled
 ALTER TABLE t1 ENABLE ROW LEVEL SECURITY;
 CREATE POLICY t1_policy ON t1 USING (false);
@@ -910,10 +916,13 @@ FROM
     JOIN t1 KEY (c1, c2) <- q2 (c11, c12)
 ) AS q1
 JOIN t7 KEY (c15, c16) -> q1 (c9, c10);
-ERROR:  foreign key join violation
-LINE 20: JOIN t7 KEY (c15, c16) -> q1 (c9, c10);
-                 ^
-DETAIL:  referenced relation does not preserve all rows
+ c11 | c12 | c15 | c16 
+-----+-----+-----+-----
+   1 |  10 |   1 |   2
+   1 |  10 |   1 |   2
+   3 |  30 |   3 |   4
+(3 rows)
+
 --
 -- Test allowed joins not affecting uniqueness
 --
@@ -1138,10 +1147,12 @@ SELECT * FROM
     SELECT c1, c2 FROM t1 WHERE c2 > 0
 ) AS u
 JOIN t2 KEY (c3, c4) -> u (c1, c2);
-ERROR:  foreign key join violation
-LINE 5: JOIN t2 KEY (c3, c4) -> u (c1, c2);
-                ^
-DETAIL:  referenced relation does not preserve all rows
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
 SELECT *
 FROM t1
 JOIN

--- a/src/test/regress/expected/foreign_key_join.out
+++ b/src/test/regress/expected/foreign_key_join.out
@@ -834,12 +834,10 @@ CREATE VIEW v2 AS
 SELECT * FROM t2 WHERE c3 > 0;
 -- invalid since v1 is filtered and is the referenced table
 SELECT * FROM v1 JOIN t2 KEY (c3) -> v1 (c1);
- c1 | c2 | c3 | c4 
-----+----+----+----
-  1 | 10 |  1 | 10
-  3 | 30 |  3 | 30
-(2 rows)
-
+ERROR:  foreign key join violation
+LINE 1: SELECT * FROM v1 JOIN t2 KEY (c3) -> v1 (c1);
+                                 ^
+DETAIL:  referenced relation does not preserve all rows
 -- OK, filtering allowed since v2 is the referencing table
 SELECT * FROM t1 JOIN v2 KEY (c3) -> t1 (c1);
  c1 | c2 | c3 | c4 
@@ -850,12 +848,10 @@ SELECT * FROM t1 JOIN v2 KEY (c3) -> t1 (c1);
 
 -- also invalid, since v1 is filtered and is the referenced table
 SELECT * FROM v1 JOIN v2 KEY (c3) -> v1 (c1);
- c1 | c2 | c3 | c4 
-----+----+----+----
-  1 | 10 |  1 | 10
-  3 | 30 |  3 | 30
-(2 rows)
-
+ERROR:  foreign key join violation
+LINE 1: SELECT * FROM v1 JOIN v2 KEY (c3) -> v1 (c1);
+                                 ^
+DETAIL:  referenced relation does not preserve all rows
 -- also invalid, filters uisng a having clause
 SELECT * FROM
 (
@@ -868,19 +864,17 @@ LINE 5: JOIN t2 KEY (c3) -> u (c1);
 -- invalid, since u is filtered and is the referenced table
 SELECT * FROM (SELECT c1 FROM t1 LIMIT 1) AS u
 JOIN t2 KEY (c3) -> u (c1);
- c1 | c3 | c4 
-----+----+----
-  1 |  1 | 10
-(1 row)
-
+ERROR:  foreign key join violation
+LINE 2: JOIN t2 KEY (c3) -> u (c1);
+                ^
+DETAIL:  referenced relation does not preserve all rows
 -- invalid, since u is filtered and is the referenced table
 SELECT * FROM (SELECT c1 FROM t1 OFFSET 1) AS u
 JOIN t2 KEY (c3) -> u (c1);
- c1 | c3 | c4 
-----+----+----
-  3 |  3 | 30
-(1 row)
-
+ERROR:  foreign key join violation
+LINE 2: JOIN t2 KEY (c3) -> u (c1);
+                ^
+DETAIL:  referenced relation does not preserve all rows
 -- invalid, since referenced table has RLS enabled
 ALTER TABLE t1 ENABLE ROW LEVEL SECURITY;
 CREATE POLICY t1_policy ON t1 USING (false);
@@ -916,13 +910,10 @@ FROM
     JOIN t1 KEY (c1, c2) <- q2 (c11, c12)
 ) AS q1
 JOIN t7 KEY (c15, c16) -> q1 (c9, c10);
- c11 | c12 | c15 | c16 
------+-----+-----+-----
-   1 |  10 |   1 |   2
-   1 |  10 |   1 |   2
-   3 |  30 |   3 |   4
-(3 rows)
-
+ERROR:  foreign key join violation
+LINE 20: JOIN t7 KEY (c15, c16) -> q1 (c9, c10);
+                 ^
+DETAIL:  referenced relation does not preserve all rows
 --
 -- Test allowed joins not affecting uniqueness
 --
@@ -1147,12 +1138,10 @@ SELECT * FROM
     SELECT c1, c2 FROM t1 WHERE c2 > 0
 ) AS u
 JOIN t2 KEY (c3, c4) -> u (c1, c2);
- c1 | c2 | c3 | c4 
-----+----+----+----
-  1 | 10 |  1 | 10
-  3 | 30 |  3 | 30
-(2 rows)
-
+ERROR:  foreign key join violation
+LINE 5: JOIN t2 KEY (c3, c4) -> u (c1, c2);
+                ^
+DETAIL:  referenced relation does not preserve all rows
 SELECT *
 FROM t1
 JOIN

--- a/src/test/regress/expected/foreign_key_join.out
+++ b/src/test/regress/expected/foreign_key_join.out
@@ -1,0 +1,1349 @@
+--
+-- Test Foreign Key Joins.
+--
+CREATE TABLE t1
+(
+    c1 int not null,
+    c2 int not null,
+    CONSTRAINT t1_pkey PRIMARY KEY (c1)
+);
+CREATE TABLE t2
+(
+    c3 int not null,
+    c4 int not null,
+    CONSTRAINT t2_pkey PRIMARY KEY (c3),
+    CONSTRAINT t2_c3_fkey FOREIGN KEY (c3) REFERENCES t1 (c1)
+);
+INSERT INTO t1 (c1, c2) VALUES (1, 10);
+INSERT INTO t1 (c1, c2) VALUES (2, 20);
+INSERT INTO t1 (c1, c2) VALUES (3, 30);
+INSERT INTO t2 (c3, c4) VALUES (1, 10);
+INSERT INTO t2 (c3, c4) VALUES (3, 30);
+--
+-- Test renaming tables and columns.
+--
+CREATE VIEW v1 AS
+SELECT *
+FROM t1
+JOIN t2 KEY (c3) -> t1 (c1);
+\d+ v1
+                             View "public.v1"
+ Column |  Type   | Collation | Nullable | Default | Storage | Description 
+--------+---------+-----------+----------+---------+---------+-------------
+ c1     | integer |           |          |         | plain   | 
+ c2     | integer |           |          |         | plain   | 
+ c3     | integer |           |          |         | plain   | 
+ c4     | integer |           |          |         | plain   | 
+View definition:
+ SELECT t1.c1,
+    t1.c2,
+    t2.c3,
+    t2.c4
+   FROM t1
+     JOIN t2 KEY (c3) -> t1 (c1);
+
+SELECT * FROM v1; -- ok
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+ALTER TABLE t1 RENAME COLUMN c1 TO c1_renamed;
+ALTER TABLE t2 RENAME COLUMN c3 TO c3_renamed;
+ALTER TABLE t1 RENAME TO t1_renamed;
+ALTER TABLE t2 RENAME TO t2_renamed;
+\d+ v1
+                             View "public.v1"
+ Column |  Type   | Collation | Nullable | Default | Storage | Description 
+--------+---------+-----------+----------+---------+---------+-------------
+ c1     | integer |           |          |         | plain   | 
+ c2     | integer |           |          |         | plain   | 
+ c3     | integer |           |          |         | plain   | 
+ c4     | integer |           |          |         | plain   | 
+View definition:
+ SELECT t1_renamed.c1_renamed AS c1,
+    t1_renamed.c2,
+    t2_renamed.c3_renamed AS c3,
+    t2_renamed.c4
+   FROM t1_renamed
+     JOIN t2_renamed KEY (c3_renamed) -> t1_renamed (c1_renamed);
+
+SELECT * FROM v1; -- ok
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+-- Undo the effect of the renames
+ALTER TABLE t2_renamed RENAME TO t2;
+ALTER TABLE t1_renamed RENAME TO t1;
+ALTER TABLE t2 RENAME COLUMN c3_renamed TO c3;
+ALTER TABLE t1 RENAME COLUMN c1_renamed TO c1;
+\d+ v1
+                             View "public.v1"
+ Column |  Type   | Collation | Nullable | Default | Storage | Description 
+--------+---------+-----------+----------+---------+---------+-------------
+ c1     | integer |           |          |         | plain   | 
+ c2     | integer |           |          |         | plain   | 
+ c3     | integer |           |          |         | plain   | 
+ c4     | integer |           |          |         | plain   | 
+View definition:
+ SELECT t1.c1,
+    t1.c2,
+    t2.c3,
+    t2.c4
+   FROM t1
+     JOIN t2 KEY (c3) -> t1 (c1);
+
+-- Test so we didn't break the parser
+SELECT 1<-2; -- ok, false
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT * FROM v1; -- ok
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c1); -- ok
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT * FROM t1 JOIN t2 KEY (c3) ->/*comment*/ t1 (c1); -- ok
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT * FROM t1 JOIN t2 KEY (c3) /*comment*/-> t1 (c1); -- ok
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT * FROM t1 JOIN t2 KEY (c3) /*comment*/->/*comment*/ t1 (c1); -- ok
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT * FROM t1 JOIN t2 KEY (c3) - > t1 (c2); -- error
+ERROR:  syntax error at or near "-"
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c3) - > t1 (c2);
+                                          ^
+SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c2); -- error
+ERROR:  there is no foreign key constraint on table "t2" (c3) referencing table "t1" (c2)
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c2);
+                                 ^
+SELECT * FROM t1 JOIN t2 KEY (c4) -> t1 (c1); -- error
+ERROR:  there is no foreign key constraint on table "t2" (c4) referencing table "t1" (c1)
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c4) -> t1 (c1);
+                                 ^
+SELECT * FROM t1 JOIN t2 KEY (c3,c4) -> t1 (c1,c2); -- error
+ERROR:  there is no foreign key constraint on table "t2" (c3, c4) referencing table "t1" (c1, c2)
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c3,c4) -> t1 (c1,c2);
+                                 ^
+SELECT * FROM t1 JOIN t2 KEY (c3) <- t1 (c1); -- error
+ERROR:  there is no foreign key constraint on table "t1" (c1) referencing table "t2" (c3)
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c3) <- t1 (c1);
+                                 ^
+SELECT * FROM t1 JOIN t2 KEY (c1) <- t1 (c3); -- error
+ERROR:  column "c3" does not exist in referencing table
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c1) <- t1 (c3);
+                                 ^
+SELECT * FROM t1 JOIN t2 KEY (c3) <- t1 (c2); -- error
+ERROR:  there is no foreign key constraint on table "t1" (c2) referencing table "t2" (c3)
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c3) <- t1 (c2);
+                                 ^
+SELECT * FROM t1 JOIN t2 KEY (c4) <- t1 (c1); -- error
+ERROR:  there is no foreign key constraint on table "t1" (c1) referencing table "t2" (c4)
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c4) <- t1 (c1);
+                                 ^
+SELECT * FROM t1 JOIN t2 KEY (c3,c4) <- t1 (c1,c2); -- error
+ERROR:  there is no foreign key constraint on table "t1" (c1, c2) referencing table "t2" (c3, c4)
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c3,c4) <- t1 (c1,c2);
+                                 ^
+SELECT * FROM t1 AS a JOIN t2 AS b KEY (c3) -> a (c2); -- error
+ERROR:  there is no foreign key constraint on table "b" (c3) referencing table "a" (c2)
+LINE 1: SELECT * FROM t1 AS a JOIN t2 AS b KEY (c3) -> a (c2);
+                                           ^
+SELECT * FROM t2 JOIN t1 KEY (c1) <- t2 (c3); -- ok
+ c3 | c4 | c1 | c2 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT * FROM t2 JOIN t1 KEY (c1) <-/*comment*/ t2 (c3); -- ok
+ c3 | c4 | c1 | c2 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT * FROM t2 JOIN t1 KEY (c1) /*comment*/<- t2 (c3); -- ok
+ c3 | c4 | c1 | c2 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT * FROM t2 JOIN t1 KEY (c1) /*comment*/<-/*comment*/ t2 (c3); -- ok
+ c3 | c4 | c1 | c2 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT * FROM t2 JOIN t1 KEY (c1) < - t2 (c3); -- error
+ERROR:  syntax error at or near "<"
+LINE 1: SELECT * FROM t2 JOIN t1 KEY (c1) < - t2 (c3);
+                                          ^
+SELECT * FROM t2 JOIN t1 KEY (c1) <- t2 (c4); -- error
+ERROR:  there is no foreign key constraint on table "t2" (c4) referencing table "t1" (c1)
+LINE 1: SELECT * FROM t2 JOIN t1 KEY (c1) <- t2 (c4);
+                                 ^
+SELECT * FROM t2 JOIN t1 KEY (c2) <- t2 (c3); -- error
+ERROR:  there is no foreign key constraint on table "t2" (c3) referencing table "t1" (c2)
+LINE 1: SELECT * FROM t2 JOIN t1 KEY (c2) <- t2 (c3);
+                                 ^
+SELECT * FROM t2 JOIN t1 KEY (c1,c2) <- t2 (c3,c4); -- error
+ERROR:  there is no foreign key constraint on table "t2" (c3, c4) referencing table "t1" (c1, c2)
+LINE 1: SELECT * FROM t2 JOIN t1 KEY (c1,c2) <- t2 (c3,c4);
+                                 ^
+SELECT * FROM t2 JOIN t1 KEY (c1) -> t2 (c3); -- error
+ERROR:  there is no foreign key constraint on table "t1" (c1) referencing table "t2" (c3)
+LINE 1: SELECT * FROM t2 JOIN t1 KEY (c1) -> t2 (c3);
+                                 ^
+SELECT * FROM t2 JOIN t1 KEY (c1) -> t2 (c4); -- error
+ERROR:  there is no foreign key constraint on table "t1" (c1) referencing table "t2" (c4)
+LINE 1: SELECT * FROM t2 JOIN t1 KEY (c1) -> t2 (c4);
+                                 ^
+SELECT * FROM t2 JOIN t1 KEY (c2) -> t2 (c3); -- error
+ERROR:  there is no foreign key constraint on table "t1" (c2) referencing table "t2" (c3)
+LINE 1: SELECT * FROM t2 JOIN t1 KEY (c2) -> t2 (c3);
+                                 ^
+SELECT * FROM t2 JOIN t1 KEY (c1,c2) -> t2 (c3,c4); -- error
+ERROR:  there is no foreign key constraint on table "t1" (c1, c2) referencing table "t2" (c3, c4)
+LINE 1: SELECT * FROM t2 JOIN t1 KEY (c1,c2) -> t2 (c3,c4);
+                                 ^
+SELECT * FROM t2 AS a JOIN t1 AS b KEY (c1) <- a (c4); -- error
+ERROR:  there is no foreign key constraint on table "a" (c4) referencing table "b" (c1)
+LINE 1: SELECT * FROM t2 AS a JOIN t1 AS b KEY (c1) <- a (c4);
+                                           ^
+ALTER TABLE t2 DROP CONSTRAINT t2_c3_fkey; -- error
+ERROR:  cannot drop constraint t2_c3_fkey on table t2 because other objects depend on it
+DETAIL:  view v1 depends on constraint t2_c3_fkey on table t2
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+DROP VIEW v1;
+ALTER TABLE t2 DROP CONSTRAINT t2_c3_fkey;
+SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c1); -- error
+ERROR:  there is no foreign key constraint on table "t2" (c3) referencing table "t1" (c1)
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c1);
+                                 ^
+SELECT * FROM t2 JOIN t1 KEY (c1) <- t2 (c3); -- error
+ERROR:  there is no foreign key constraint on table "t2" (c3) referencing table "t1" (c1)
+LINE 1: SELECT * FROM t2 JOIN t1 KEY (c1) <- t2 (c3);
+                                 ^
+ALTER TABLE t1 ADD UNIQUE (c1,c2);
+ALTER TABLE t2 ADD CONSTRAINT t2_c3_c4_fkey FOREIGN KEY (c3,c4) REFERENCES t1 (c1,c2);
+CREATE VIEW v2 AS
+SELECT * FROM t1 JOIN t2 KEY (c3,c4) -> t1 (c1,c2); -- ok
+SELECT * FROM t1 JOIN t2 KEY (c3,c4) -> t1 (c1,c2); -- ok
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT * FROM v2; -- ok
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+\d+ v2
+                             View "public.v2"
+ Column |  Type   | Collation | Nullable | Default | Storage | Description 
+--------+---------+-----------+----------+---------+---------+-------------
+ c1     | integer |           |          |         | plain   | 
+ c2     | integer |           |          |         | plain   | 
+ c3     | integer |           |          |         | plain   | 
+ c4     | integer |           |          |         | plain   | 
+View definition:
+ SELECT t1.c1,
+    t1.c2,
+    t2.c3,
+    t2.c4
+   FROM t1
+     JOIN t2 KEY (c3, c4) -> t1 (c1, c2);
+
+CREATE VIEW v3 AS
+SELECT * FROM t2 JOIN t1 KEY (c1,c2) <- t2 (c3,c4); -- ok
+SELECT * FROM t2 JOIN t1 KEY (c1,c2) <- t2 (c3,c4); -- ok
+ c3 | c4 | c1 | c2 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+\d+ v3
+                             View "public.v3"
+ Column |  Type   | Collation | Nullable | Default | Storage | Description 
+--------+---------+-----------+----------+---------+---------+-------------
+ c3     | integer |           |          |         | plain   | 
+ c4     | integer |           |          |         | plain   | 
+ c1     | integer |           |          |         | plain   | 
+ c2     | integer |           |          |         | plain   | 
+View definition:
+ SELECT t2.c3,
+    t2.c4,
+    t1.c1,
+    t1.c2
+   FROM t2
+     JOIN t1 KEY (c1, c2) <- t2 (c3, c4);
+
+SELECT * FROM v3; -- ok
+ c3 | c4 | c1 | c2 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c1); -- error
+ERROR:  there is no foreign key constraint on table "t2" (c3) referencing table "t1" (c1)
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c1);
+                                 ^
+SELECT * FROM t2 JOIN t1 KEY (c1) <- t2 (c3); -- error
+ERROR:  there is no foreign key constraint on table "t2" (c3) referencing table "t1" (c1)
+LINE 1: SELECT * FROM t2 JOIN t1 KEY (c1) <- t2 (c3);
+                                 ^
+SELECT * FROM t1 JOIN t2 KEY (c3,c4) <- t1 (c1,c2); -- error
+ERROR:  there is no foreign key constraint on table "t1" (c1, c2) referencing table "t2" (c3, c4)
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c3,c4) <- t1 (c1,c2);
+                                 ^
+SELECT * FROM t2 JOIN t1 KEY (c1,c2) -> t2 (c3,c4); -- error
+ERROR:  there is no foreign key constraint on table "t1" (c1, c2) referencing table "t2" (c3, c4)
+LINE 1: SELECT * FROM t2 JOIN t1 KEY (c1,c2) -> t2 (c3,c4);
+                                 ^
+--
+-- Test nulls and multiple tables
+--
+CREATE TABLE t3
+(
+    c5 int,
+    c6 int,
+    CONSTRAINT t3_c5_c6_fkey FOREIGN KEY (c5, c6) REFERENCES t1 (c1, c2)
+);
+INSERT INTO t3 (c5, c6) VALUES (1, 10); -- ok
+INSERT INTO t3 (c5, c6) VALUES (3, 30); -- ok
+INSERT INTO t3 (c5, c6) VALUES (3, NULL); -- ok
+INSERT INTO t3 (c5, c6) VALUES (NULL, 30); -- ok
+INSERT INTO t3 (c5, c6) VALUES (1234, NULL); -- ok
+INSERT INTO t3 (c5, c6) VALUES (NULL, 5678); -- ok
+INSERT INTO t3 (c5, c6) VALUES (NULL, NULL); -- ok
+--
+-- Test composite foreign key joins with columns in matching order
+--
+SELECT *
+FROM t1
+JOIN t2 KEY (c3,c4) -> t1 (c1,c2)
+JOIN t3 KEY (c5,c6) -> t1 (c1,c2);
+ c1 | c2 | c3 | c4 | c5 | c6 
+----+----+----+----+----+----
+  1 | 10 |  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT *
+FROM t1
+JOIN t2 KEY (c3,c4) -> t1 (c1,c2)
+LEFT JOIN t3 KEY (c5,c6) -> t1 (c1,c2);
+ c1 | c2 | c3 | c4 | c5 | c6 
+----+----+----+----+----+----
+  1 | 10 |  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT *
+FROM t1
+JOIN t2 KEY (c3,c4) -> t1 (c1,c2)
+RIGHT JOIN t3 KEY (c5,c6) -> t1 (c1,c2);
+ c1 | c2 | c3 | c4 |  c5  |  c6  
+----+----+----+----+------+------
+  1 | 10 |  1 | 10 |    1 |   10
+  3 | 30 |  3 | 30 |    3 |   30
+    |    |    |    |    3 |     
+    |    |    |    | 1234 |     
+    |    |    |    |      |   30
+    |    |    |    |      | 5678
+    |    |    |    |      |     
+(7 rows)
+
+--
+-- Test composite foreign key joins with swapped column orders
+--
+SELECT *
+FROM t1
+JOIN t2 KEY (c4,c3) -> t1 (c2,c1)
+JOIN t3 KEY (c6,c5) -> t1 (c2,c1);
+ c1 | c2 | c3 | c4 | c5 | c6 
+----+----+----+----+----+----
+  1 | 10 |  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30 |  3 | 30
+(2 rows)
+
+--
+-- Test mismatched column orders between referencing and referenced sides
+--
+SELECT *
+FROM t1
+JOIN t2 KEY (c4,c3) -> t1 (c2,c1)
+JOIN t3 KEY (c6,c5) -> t1 (c1,c2); -- error
+ERROR:  there is no foreign key constraint on table "t3" (c6, c5) referencing table "t1" (c1, c2)
+LINE 4: JOIN t3 KEY (c6,c5) -> t1 (c1,c2);
+                ^
+--
+-- Test defining foreign key constraints with MATCH FULL
+--
+CREATE TABLE t4
+(
+    c7 int,
+    c8 int,
+    CONSTRAINT t4_c7_c8_fkey FOREIGN KEY (c7, c8) REFERENCES t1 (c1, c2) MATCH FULL
+);
+INSERT INTO t4 (c7, c8) VALUES (1, 10); -- ok
+INSERT INTO t4 (c7, c8) VALUES (3, 30); -- ok
+INSERT INTO t4 (c7, c8) VALUES (3, NULL); -- error
+ERROR:  insert or update on table "t4" violates foreign key constraint "t4_c7_c8_fkey"
+DETAIL:  MATCH FULL does not allow mixing of null and nonnull key values.
+INSERT INTO t4 (c7, c8) VALUES (NULL, 30); -- error
+ERROR:  insert or update on table "t4" violates foreign key constraint "t4_c7_c8_fkey"
+DETAIL:  MATCH FULL does not allow mixing of null and nonnull key values.
+INSERT INTO t4 (c7, c8) VALUES (1234, NULL); -- error
+ERROR:  insert or update on table "t4" violates foreign key constraint "t4_c7_c8_fkey"
+DETAIL:  MATCH FULL does not allow mixing of null and nonnull key values.
+INSERT INTO t4 (c7, c8) VALUES (NULL, 5678); -- error
+ERROR:  insert or update on table "t4" violates foreign key constraint "t4_c7_c8_fkey"
+DETAIL:  MATCH FULL does not allow mixing of null and nonnull key values.
+INSERT INTO t4 (c7, c8) VALUES (NULL, NULL); -- ok
+SELECT *
+FROM t1
+JOIN t2 KEY (c3,c4) -> t1 (c1,c2)
+JOIN t4 KEY (c7,c8) -> t1 (c1,c2);
+ c1 | c2 | c3 | c4 | c7 | c8 
+----+----+----+----+----+----
+  1 | 10 |  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT *
+FROM t1
+JOIN t2 KEY (c3,c4) -> t1 (c1,c2)
+LEFT JOIN t4 KEY (c7,c8) -> t1 (c1,c2);
+ c1 | c2 | c3 | c4 | c7 | c8 
+----+----+----+----+----+----
+  1 | 10 |  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT *
+FROM t1
+JOIN t2 KEY (c3,c4) -> t1 (c1,c2)
+RIGHT JOIN t4 KEY (c7,c8) -> t1 (c1,c2);
+ c1 | c2 | c3 | c4 | c7 | c8 
+----+----+----+----+----+----
+  1 | 10 |  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30 |  3 | 30
+    |    |    |    |    |   
+(3 rows)
+
+-- Recrate stuff for pg_dump tests
+ALTER TABLE t2
+    ADD CONSTRAINT t2_c3_fkey FOREIGN KEY (c3) REFERENCES t1 (c1);
+CREATE VIEW v1 AS
+SELECT *
+FROM t1
+JOIN t2 KEY (c3) -> t1 (c1);
+CREATE TABLE t5
+(
+    c9 int not null,
+    c10 int not null,
+    c11 int not null,
+    c12 int not null,
+    CONSTRAINT t5_pkey PRIMARY KEY (c9, c10),
+    CONSTRAINT t5_c11_c12_fkey FOREIGN KEY (c11, c12) REFERENCES t1 (c1, c2)
+);
+INSERT INTO t5 (c9, c10, c11, c12) VALUES (1, 2, 1, 10);
+INSERT INTO t5 (c9, c10, c11, c12) VALUES (3, 4, 3, 30);
+CREATE TABLE t6
+(
+    c13 int not null,
+    c14 int not null,
+    CONSTRAINT t6_c13_c14_fkey FOREIGN KEY (c13, c14) REFERENCES t5 (c9, c10)
+);
+INSERT INTO t6 (c13, c14) VALUES (1, 2);
+INSERT INTO t6 (c13, c14) VALUES (3, 4);
+INSERT INTO t6 (c13, c14) VALUES (3, 4);
+CREATE TABLE t7
+(
+    c15 int not null,
+    c16 int not null,
+    CONSTRAINT t7_c15_c16_fkey FOREIGN KEY (c15, c16) REFERENCES t5 (c9, c10)
+);
+INSERT INTO t7 (c15, c16) VALUES (1, 2);
+INSERT INTO t7 (c15, c16) VALUES (1, 2);
+INSERT INTO t7 (c15, c16) VALUES (3, 4);
+CREATE TABLE t8
+(
+    c17 int not null,
+    c18 int not null,
+    c19 int,
+    c20 int,
+    CONSTRAINT t8_pkey PRIMARY KEY (c17, c18),
+    CONSTRAINT t8_c19_c20_fkey FOREIGN KEY (c19, c20) REFERENCES t1 (c1, c2)
+);
+INSERT INTO t8 (c17, c18, c19, c20) VALUES (1, 2, 1, 10);
+INSERT INTO t8 (c17, c18, c19, c20) VALUES (3, 4, 3, 30);
+CREATE TABLE t9
+(
+    c21 int not null,
+    c22 int not null,
+    CONSTRAINT t9_c21_c22_fkey FOREIGN KEY (c21, c22) REFERENCES t8 (c17, c18)
+);
+INSERT INTO t9 (c21, c22) VALUES (1, 2);
+INSERT INTO t9 (c21, c22) VALUES (3, 4);
+INSERT INTO t9 (c21, c22) VALUES (3, 4);
+CREATE TABLE t10
+(
+    c23 INT NOT NULL,
+    c24 INT NOT NULL,
+    c25 INT NOT NULL,
+    c26 INT NOT NULL,
+    CONSTRAINT t10_pkey PRIMARY KEY (c23, c24),
+    CONSTRAINT t10_c23_c24_fkey FOREIGN KEY (c23, c24) REFERENCES t1 (c1, c2),
+    CONSTRAINT t10_c25_c26_fkey FOREIGN KEY (c25, c26) REFERENCES t10 (c23, c24)
+);
+INSERT INTO t10 (c23, c24, c25, c26) VALUES (1, 10, 1, 10);
+CREATE TABLE t11
+(
+    c27 INT NOT NULL,
+    c28 INT NOT NULL,
+    CONSTRAINT t11_pkey PRIMARY KEY (c27, c28),
+    CONSTRAINT t11_c27_c28_fkey FOREIGN KEY (c27, c28) REFERENCES t10 (c23, c24)
+);
+INSERT INTO t11 (c27, c28) VALUES (1, 10);
+--
+-- Test subqueries
+--
+SELECT
+    a.c1,
+    a.c2,
+    b.c3,
+    b.c4
+FROM t1 AS a
+JOIN
+(
+    SELECT * FROM t2
+) AS b KEY (c3) -> a (c1);
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT
+    a.c1,
+    a.c2,
+    b.c3,
+    b.c4
+FROM
+(
+    SELECT * FROM t1
+) AS a
+JOIN
+(
+    SELECT * FROM t2
+) AS b KEY (c3) -> a (c1);
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+SELECT
+    a.t1_c1,
+    a.t1_c2,
+    b.t2_c3,
+    b.t2_c4
+FROM
+(
+    SELECT c1 AS t1_c1, c2 AS t1_c2 FROM t1
+) AS a
+JOIN
+(
+    SELECT c3 AS t2_c3, c4 AS t2_c4 FROM t2
+) AS b KEY (t2_c3) -> a (t1_c1);
+ t1_c1 | t1_c2 | t2_c3 | t2_c4 
+-------+-------+-------+-------
+     1 |    10 |     1 |    10
+     3 |    30 |     3 |    30
+(2 rows)
+
+SELECT
+    a.outer_c1,
+    a.outer_c2,
+    b.outer_c3,
+    b.outer_c4
+FROM
+(
+    SELECT mid_c1 AS outer_c1, mid_c2 AS outer_c2 FROM
+    (
+        SELECT c1 AS mid_c1, c2 AS mid_c2 FROM t1
+    ) sub1
+) AS a
+JOIN
+(
+    SELECT mid_c3 AS outer_c3, mid_c4 AS outer_c4 FROM
+    (
+        SELECT c3 AS mid_c3, c4 AS mid_c4 FROM t2
+    ) sub2
+) AS b KEY (outer_c3) -> a (outer_c1);
+ outer_c1 | outer_c2 | outer_c3 | outer_c4 
+----------+----------+----------+----------
+        1 |       10 |        1 |       10
+        3 |       30 |        3 |       30
+(2 rows)
+
+SELECT *
+FROM t1
+JOIN
+(
+    SELECT
+        t10.c23,
+        t10.c24,
+        t10_2.c25,
+        t10_2.c26
+    FROM t10
+    JOIN t10 AS t10_2 KEY (c23, c24) <- t10 (c25, c26)
+) AS q1 KEY (c23, c24) -> t1 (c1, c2);
+ c1 | c2 | c23 | c24 | c25 | c26 
+----+----+-----+-----+-----+-----
+  1 | 10 |   1 |  10 |   1 |  10
+(1 row)
+
+SELECT *
+FROM t1
+JOIN LATERAL (
+    SELECT c3, c4 FROM t2 WHERE c4 = c1 + 9
+) AS q1 KEY (c3) -> t1 (c1);
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | 10 |  1 | 10
+(1 row)
+
+--
+-- Test CTEs
+--
+WITH
+q1 (q1_c1, q1_c2) AS
+(
+    SELECT c1, c2 FROM t1
+),
+q2 (q2_c1, q2_c2) AS
+(
+    SELECT q1_c1, q1_c2 FROM q1
+),
+q3 (q3_c3, q3_c4) AS
+(
+    SELECT c3, c4 FROM t2
+),
+q4 (q4_c3, q4_c4) AS
+(
+    SELECT q3_c3, q3_c4 FROM q3
+)
+SELECT
+    q2_c1,
+    q2_c2,
+    q4_c3,
+    q4_c4
+FROM q2 JOIN q4 KEY (q4_c3, q4_c4) -> q2 (q2_c1, q2_c2);
+ q2_c1 | q2_c2 | q4_c3 | q4_c4 
+-------+-------+-------+-------
+     1 |    10 |     1 |    10
+     3 |    30 |     3 |    30
+(2 rows)
+
+WITH RECURSIVE q1 AS (SELECT c1 FROM t1 UNION SELECT c1 FROM q1)
+SELECT * FROM q1 JOIN t2 KEY (c3) -> q1 (c1);
+ERROR:  foreign key joins involving this type of relation are not supported
+LINE 2: SELECT * FROM q1 JOIN t2 KEY (c3) -> q1 (c1);
+                                 ^
+--
+-- Test VIEWs
+--
+DROP VIEW v1, v2, v3;
+CREATE VIEW v1 AS
+SELECT c1 AS v1_c1, c2 AS v1_c2 FROM t1;
+CREATE VIEW v2 AS
+SELECT v1_c1 AS v2_c1, v1_c2 AS v2_c2 FROM v1;
+CREATE VIEW v3 AS
+SELECT c3 AS v3_c3, c4 AS v3_c4 FROM t2;
+CREATE VIEW v4 AS
+SELECT v3_c3 AS v4_c3, v3_c4 AS v4_c4 FROM v3;
+CREATE VIEW v5 AS
+SELECT
+    v2_c1,
+    v2_c2,
+    v4_c3,
+    v4_c4
+FROM v2 JOIN v4 KEY (v4_c3, v4_c4) -> v2 (v2_c1, v2_c2);
+SELECT * FROM v5;
+ v2_c1 | v2_c2 | v4_c3 | v4_c4 
+-------+-------+-------+-------
+     1 |    10 |     1 |    10
+     3 |    30 |     3 |    30
+(2 rows)
+
+--
+-- Test subqueries, CTEs, and views
+--
+WITH
+q2 (q2_c1, q2_c2) AS
+(
+    SELECT
+        q1_c1,
+        q1_c2
+    FROM
+    (
+        SELECT c1 AS q1_c1, c2 AS q1_c2 FROM t1
+    ) AS q1
+)
+SELECT
+    q2_c1,
+    q2_c2,
+    v4_c3,
+    v4_c4
+FROM q2 JOIN v4 KEY (v4_c3, v4_c4) -> q2 (q2_c1, q2_c2);
+ q2_c1 | q2_c2 | v4_c3 | v4_c4 
+-------+-------+-------+-------
+     1 |    10 |     1 |    10
+     3 |    30 |     3 |    30
+(2 rows)
+
+DROP VIEW v1, v2, v3, v4, v5;
+--
+-- Test subqueries, CTEs and VIEWs containing joins
+--
+SELECT
+    q1.c11,
+    q1.c12,
+    t6.c13,
+    t6.c14
+FROM
+(
+    SELECT
+        t5.c9,
+        t5.c10,
+        t5.c11,
+        t5.c12
+    FROM t5
+    JOIN t1 KEY (c1, c2) <- t5 (c11, c12)
+    JOIN t1 AS t1_2 KEY (c1, c2) <- t5 (c11, c12)
+    JOIN t1 AS t1_3 KEY (c1, c2) <- t5 (c11, c12)
+) AS q1
+JOIN t6 KEY (c13, c14) -> q1 (c9, c10);
+ c11 | c12 | c13 | c14 
+-----+-----+-----+-----
+   1 |  10 |   1 |   2
+   3 |  30 |   3 |   4
+   3 |  30 |   3 |   4
+(3 rows)
+
+WITH
+q1 AS
+(
+    SELECT
+        t5.c9,
+        t5.c10,
+        t5.c11,
+        t5.c12
+    FROM t5
+    JOIN t1 KEY (c1, c2) <- t5 (c11, c12)
+    JOIN t1 AS t1_2 KEY (c1, c2) <- t5 (c11, c12)
+    JOIN t1 AS t1_3 KEY (c1, c2) <- t5 (c11, c12)
+)
+SELECT
+    q1.c11,
+    q1.c12,
+    t6.c13,
+    t6.c14
+FROM q1
+JOIN t6 KEY (c13, c14) -> q1 (c9, c10);
+ c11 | c12 | c13 | c14 
+-----+-----+-----+-----
+   1 |  10 |   1 |   2
+   3 |  30 |   3 |   4
+   3 |  30 |   3 |   4
+(3 rows)
+
+CREATE VIEW v1 AS
+SELECT
+    t5.c9,
+    t5.c10,
+    t5.c11,
+    t5.c12
+FROM t5
+JOIN t1 KEY (c1, c2) <- t5 (c11, c12)
+JOIN t1 AS t1_2 KEY (c1, c2) <- t5 (c11, c12)
+JOIN t1 AS t1_3 KEY (c1, c2) <- t5 (c11, c12);
+SELECT
+    v1.c11,
+    v1.c12,
+    t6.c13,
+    t6.c14
+FROM v1
+JOIN t6 KEY (c13, c14) -> v1 (c9, c10);
+ c11 | c12 | c13 | c14 
+-----+-----+-----+-----
+   1 |  10 |   1 |   2
+   3 |  30 |   3 |   4
+   3 |  30 |   3 |   4
+(3 rows)
+
+DROP VIEW v1;
+--
+-- Test disallowed filtering of referenced table
+--
+CREATE VIEW v1 AS
+SELECT * FROM t1 WHERE c1 > 0;
+CREATE VIEW v2 AS
+SELECT * FROM t2 WHERE c3 > 0;
+-- invalid since v1 is filtered and is the referenced table
+SELECT * FROM v1 JOIN t2 KEY (c3) -> v1 (c1);
+ERROR:  foreign key join violation
+LINE 1: SELECT * FROM v1 JOIN t2 KEY (c3) -> v1 (c1);
+                                 ^
+DETAIL:  referenced relation does not preserve all rows
+-- OK, filtering allowed since v2 is the referencing table
+SELECT * FROM t1 JOIN v2 KEY (c3) -> t1 (c1);
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | 10 |  1 | 10
+  3 | 30 |  3 | 30
+(2 rows)
+
+-- also invalid, since v1 is filtered and is the referenced table
+SELECT * FROM v1 JOIN v2 KEY (c3) -> v1 (c1);
+ERROR:  foreign key join violation
+LINE 1: SELECT * FROM v1 JOIN v2 KEY (c3) -> v1 (c1);
+                                 ^
+DETAIL:  referenced relation does not preserve all rows
+-- also invalid, filters uisng a having clause
+SELECT * FROM
+(
+    SELECT c1, count(*) FROM t1 GROUP BY c1 HAVING c2 > 100
+) AS u
+JOIN t2 KEY (c3) -> u (c1);
+ERROR:  foreign key joins not supported for these relations
+LINE 5: JOIN t2 KEY (c3) -> u (c1);
+                ^
+-- invalid, since u is filtered and is the referenced table
+SELECT * FROM (SELECT c1 FROM t1 LIMIT 1) AS u
+JOIN t2 KEY (c3) -> u (c1);
+ERROR:  foreign key join violation
+LINE 2: JOIN t2 KEY (c3) -> u (c1);
+                ^
+DETAIL:  referenced relation does not preserve all rows
+-- invalid, since u is filtered and is the referenced table
+SELECT * FROM (SELECT c1 FROM t1 OFFSET 1) AS u
+JOIN t2 KEY (c3) -> u (c1);
+ERROR:  foreign key join violation
+LINE 2: JOIN t2 KEY (c3) -> u (c1);
+                ^
+DETAIL:  referenced relation does not preserve all rows
+-- invalid, since referenced table has RLS enabled
+ALTER TABLE t1 ENABLE ROW LEVEL SECURITY;
+CREATE POLICY t1_policy ON t1 USING (false);
+SELECT * FROM (SELECT c1 FROM t1) AS u
+JOIN t2 KEY (c3) -> u (c1);
+ERROR:  foreign key join violation
+LINE 2: JOIN t2 KEY (c3) -> u (c1);
+                ^
+DETAIL:  referenced relation does not preserve all rows
+SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c1);
+ERROR:  foreign key join violation
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c1);
+                                 ^
+DETAIL:  referenced relation does not preserve all rows
+ALTER TABLE t1 DISABLE ROW LEVEL SECURITY;
+WITH q2 AS
+(
+    SELECT * FROM t5 WHERE t5.c11 > 0
+)
+SELECT
+    q1.c11,
+    q1.c12,
+    t7.c15,
+    t7.c16
+FROM
+(
+    SELECT
+        q2.c9,
+        q2.c10,
+        q2.c11,
+        q2.c12
+    FROM q2
+    JOIN t1 KEY (c1, c2) <- q2 (c11, c12)
+) AS q1
+JOIN t7 KEY (c15, c16) -> q1 (c9, c10);
+ERROR:  foreign key join violation
+LINE 20: JOIN t7 KEY (c15, c16) -> q1 (c9, c10);
+                 ^
+DETAIL:  referenced relation does not preserve all rows
+--
+-- Test allowed joins not affecting uniqueness
+--
+SELECT
+    q1.c11,
+    q1.c12,
+    t6.c13,
+    t6.c14
+FROM
+(
+    SELECT
+        t5.c9,
+        t5.c10,
+        t5.c11,
+        t5.c12
+    FROM t5
+    JOIN t1 KEY (c1, c2) <- t5 (c11, c12)
+) AS q1
+JOIN t6 KEY (c13, c14) -> q1 (c9, c10);
+ c11 | c12 | c13 | c14 
+-----+-----+-----+-----
+   1 |  10 |   1 |   2
+   3 |  30 |   3 |   4
+   3 |  30 |   3 |   4
+(3 rows)
+
+--
+-- Test disallowed non-unique referenced table
+--
+SELECT
+    q1.c11,
+    q1.c12,
+    t7.c15,
+    t7.c16
+FROM
+(
+    SELECT
+        t5.c9,
+        t5.c10,
+        t5.c11,
+        t5.c12
+    FROM t5
+    JOIN t1 KEY (c1, c2) <- t5 (c11, c12)
+    JOIN t6 KEY (c13, c14) -> t5 (c9, c10)
+) AS q1
+JOIN t7 KEY (c15, c16) -> q1 (c9, c10);
+ERROR:  foreign key join violation
+LINE 17: JOIN t7 KEY (c15, c16) -> q1 (c9, c10);
+                 ^
+DETAIL:  referenced relation does not preserve uniqueness of keys
+SELECT
+    q1.c19,
+    q1.c20,
+    t9.c21,
+    t9.c22
+FROM
+(
+    SELECT
+        t8.c17,
+        t8.c18,
+        t8.c19,
+        t8.c20
+    FROM t8
+    JOIN t1 KEY (c1, c2) <- t8 (c19, c20)
+) AS q1
+JOIN t9 KEY (c21, c22) -> q1 (c17, c18);
+ERROR:  foreign key join violation
+LINE 16: JOIN t9 KEY (c21, c22) -> q1 (c17, c18);
+                 ^
+DETAIL:  referenced relation does not preserve all rows
+--
+-- Test revalidation of views
+--
+CREATE TABLE addresses
+(
+    id           INTEGER      NOT NULL,
+    street       VARCHAR(255) NOT NULL,
+    city         VARCHAR(100) NOT NULL,
+    state        VARCHAR(100) NOT NULL,
+    country_code CHAR(2)      NOT NULL,
+    zip_code     VARCHAR(20)  NOT NULL,
+    CONSTRAINT addresses_pkey PRIMARY KEY (id)
+);
+CREATE TABLE customers
+(
+    id         INTEGER      NOT NULL,
+    name       VARCHAR(255) NOT NULL,
+    address_id INTEGER      NOT NULL,
+    CONSTRAINT customers_pkey            PRIMARY KEY (id),
+    CONSTRAINT customers_address_id_fkey FOREIGN KEY (address_id) REFERENCES addresses (id)
+);
+CREATE TABLE orders
+(
+    id           BIGINT         NOT NULL,
+    order_date   DATE           NOT NULL,
+    amount       DECIMAL(10, 2) NOT NULL,
+    customer_id  INTEGER        NOT NULL,
+    CONSTRAINT orders_pkey             PRIMARY KEY (id),
+    CONSTRAINT orders_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES customers (id)
+);
+CREATE VIEW customer_details AS
+SELECT
+    c.id AS customer_id,
+    c.name AS customer_name,
+    a.street,
+    a.city,
+    a.state,
+    a.country_code,
+    a.zip_code
+FROM customers AS c
+JOIN addresses AS a KEY (id) <- c (address_id);
+CREATE VIEW orders_by_country AS
+SELECT
+    cd.country_code,
+    COUNT(*) AS order_count,
+    SUM(o.amount) AS total_amount
+FROM orders AS o
+JOIN customer_details AS cd KEY (customer_id) <- o (customer_id)
+GROUP BY ROLLUP (cd.country_code);
+CREATE TABLE customer_addresses
+(
+    customer_id INTEGER NOT NULL,
+    address_id INTEGER NOT NULL,
+    CONSTRAINT customer_addresses_pkey             PRIMARY KEY (customer_id, address_id),
+    CONSTRAINT customer_addresses_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES customers (id),
+    CONSTRAINT customer_addresses_address_id_fkey  FOREIGN KEY (address_id) REFERENCES addresses (id)
+);
+-- error, since it would invalidate foreign key join in orders_by_country
+-- that uses customer_details
+CREATE OR REPLACE VIEW customer_details AS
+SELECT
+    c.id AS customer_id,
+    c.name AS customer_name,
+    a.street,
+    a.city,
+    a.state,
+    a.country_code,
+    a.zip_code
+FROM customers AS c
+JOIN customer_addresses AS ca KEY (customer_id) -> c (id)
+JOIN addresses AS a KEY (id) <- ca (address_id);
+ERROR:  virtual foreign key constraint violation while re-validating view "public.orders_by_country"
+--
+-- Test various error conditions
+--
+SELECT * FROM t1 JOIN t2 KEY (c3, c4) -> t3 (c1, c2);
+ERROR:  table reference "t3" not found
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c3, c4) -> t3 (c1, c2);
+                                 ^
+SELECT * FROM t1 JOIN t2 KEY (c3, c4) -> t1 (c1);
+ERROR:  number of referencing and referenced columns must be the same
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c3, c4) -> t1 (c1);
+                                 ^
+SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c1, c2);
+ERROR:  number of referencing and referenced columns must be the same
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c1, c2);
+                                 ^
+SELECT * FROM t1 JOIN t2 KEY (c3, c4) -> t1 (c1, c2, c3);
+ERROR:  number of referencing and referenced columns must be the same
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c3, c4) -> t1 (c1, c2, c3);
+                                 ^
+SELECT * FROM t1 JOIN t2 KEY (c3, c4, c5) -> t1 (c1, c2);
+ERROR:  number of referencing and referenced columns must be the same
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c3, c4, c5) -> t1 (c1, c2);
+                                 ^
+CREATE FUNCTION t2() RETURNS TABLE (c3 INTEGER, c4 INTEGER)
+LANGUAGE sql
+BEGIN ATOMIC
+    SELECT 1, 2;
+END;
+SELECT * FROM t1 JOIN t2() KEY (c3, c4) -> t1 (c1, c2);
+ERROR:  foreign key joins involving this type of relation are not supported
+LINE 1: SELECT * FROM t1 JOIN t2() KEY (c3, c4) -> t1 (c1, c2);
+                                   ^
+SELECT * FROM t1 JOIN t2 KEY (c3, c4) -> t1 (c1, c5);
+ERROR:  column "c5" does not exist in referenced table
+LINE 1: SELECT * FROM t1 JOIN t2 KEY (c3, c4) -> t1 (c1, c5);
+                                 ^
+DROP VIEW v1, v2;
+CREATE VIEW v1 AS SELECT c1 AS c1_1, c1 AS c1_2, c2 AS c2_1, c2 AS c2_2 FROM t1;
+CREATE VIEW v2 AS SELECT c3 AS c3_1, c3 AS c3_2, c4 AS c4_1, c4 AS c4_2 FROM t2;
+SELECT * FROM v1 JOIN t2 KEY (c3, c4) -> v1 (c1_1, c2_1); -- ok
+ c1_1 | c1_2 | c2_1 | c2_2 | c3 | c4 
+------+------+------+------+----+----
+    1 |    1 |   10 |   10 |  1 | 10
+    3 |    3 |   30 |   30 |  3 | 30
+(2 rows)
+
+SELECT * FROM v1 JOIN t2 KEY (c3, c4) -> v1 (c1_1, c1_2);
+ERROR:  there is no foreign key constraint on table "t2" (c3, c4) referencing table "v1" (c1_1, c1_2)
+LINE 1: SELECT * FROM v1 JOIN t2 KEY (c3, c4) -> v1 (c1_1, c1_2);
+                                 ^
+SELECT * FROM v1 JOIN t2 KEY (c3, c4) -> v1 (c1_1, nonexistent);
+ERROR:  column "nonexistent" does not exist in referenced table
+LINE 1: SELECT * FROM v1 JOIN t2 KEY (c3, c4) -> v1 (c1_1, nonexiste...
+                                 ^
+/*
+ * We don't need to check for duplicate columns,
+ * since there is already such a check for foreign key constraints.
+ */
+SELECT * FROM v1 JOIN t2 KEY (c3, c3) -> v1 (c1_1, c1_1);
+ERROR:  there is no foreign key constraint on table "t2" (c3, c3) referencing table "v1" (c1_1, c1_1)
+LINE 5: SELECT * FROM v1 JOIN t2 KEY (c3, c3) -> v1 (c1_1, c1_1);
+                                 ^
+DROP VIEW v1;
+CREATE VIEW v1 AS SELECT c1+0 AS c1_1, c1 AS c1_2, c2 AS c2_1, c2 AS c2_2 FROM t1;
+SELECT * FROM v1 JOIN t2 KEY (c3, c4) -> v1 (c1_1, c2_1);
+ERROR:  target entry "c1_1" is an expression, not a direct column reference
+LINE 1: SELECT * FROM v1 JOIN t2 KEY (c3, c4) -> v1 (c1_1, c2_1);
+                                 ^
+SELECT * FROM t1 JOIN
+(
+    SELECT c3, c4 FROM t2
+    UNION ALL
+    SELECT c3, c4 FROM t2
+) AS u KEY (c3, c4) -> t1 (c1, c2);
+ERROR:  foreign key joins involving set operations are not supported
+LINE 6: ) AS u KEY (c3, c4) -> t1 (c1, c2);
+               ^
+SELECT * FROM
+(
+    SELECT c1, c2 FROM t1 WHERE c2 > 0
+) AS u
+JOIN t2 KEY (c3, c4) -> u (c1, c2);
+ERROR:  foreign key join violation
+LINE 5: JOIN t2 KEY (c3, c4) -> u (c1, c2);
+                ^
+DETAIL:  referenced relation does not preserve all rows
+SELECT *
+FROM t1
+JOIN
+(
+    SELECT * FROM t10
+    JOIN t10 AS t10_2 KEY (c23, c24) <- t10 (c25, c26)
+) AS q1 KEY (c23, c24) -> t1 (c1, c2);
+ERROR:  common column name "c23" appears more than once in referencing table
+LINE 7: ) AS q1 KEY (c23, c24) -> t1 (c1, c2);
+                ^
+SELECT *
+FROM t1
+JOIN
+(
+    SELECT
+        t10.c23,
+        t10.c24,
+        t10_2.c25,
+        t10_2.c26
+    FROM t10
+    JOIN t10 AS t10_2 KEY (c23, c24) <- t10 (c25, c26)
+) AS q1 KEY (nonexistent, c24) -> t1 (c1, c2);
+ERROR:  column "nonexistent" does not exist in referencing table
+LINE 12: ) AS q1 KEY (nonexistent, c24) -> t1 (c1, c2);
+                 ^
+SELECT *
+FROM t1
+JOIN
+(
+    SELECT
+        t10.c23,
+        t10_2.c24
+    FROM t10
+    JOIN t10 AS t10_2 KEY (c23, c24) <- t10 (c25, c26)
+) AS q1 KEY (c23, c24) -> t1 (c1, c2);
+ERROR:  key columns must all come from the same table
+LINE 7:         t10_2.c24
+                ^
+--
+-- Test materialized views (not supported)
+--
+CREATE MATERIALIZED VIEW mv1 AS
+SELECT c1, c2 FROM t1;
+SELECT * FROM mv1 JOIN t2 KEY (c3, c4) -> mv1 (c1, c2);
+ERROR:  foreign key joins involving this type of relation are not supported
+LINE 1: SELECT * FROM mv1 JOIN t2 KEY (c3, c4) -> mv1 (c1, c2);
+                                  ^
+DETAIL:  This operation is not supported for materialized views.
+DROP MATERIALIZED VIEW mv1;
+--
+-- Test nested foreign keyjoins
+--
+CREATE TABLE t12 (id integer PRIMARY KEY);
+CREATE TABLE t13 (id integer PRIMARY KEY, a_id integer REFERENCES t12(id));
+CREATE TABLE t14 (id integer PRIMARY KEY, b_id integer REFERENCES t13(id));
+CREATE TABLE t15 (
+    id integer,
+    id2 integer,
+    PRIMARY KEY (id, id2)
+);
+CREATE TABLE t16 (
+    id integer,
+    id2 integer,
+    a_id integer,
+    a_id2 integer,
+    PRIMARY KEY (id, id2),
+    FOREIGN KEY (a_id, a_id2) REFERENCES t15 (id, id2)
+);
+CREATE TABLE t17 (
+    id integer,
+    id2 integer,
+    b_id integer,
+    b_id2 integer,
+    PRIMARY KEY (id, id2),
+    FOREIGN KEY (b_id, b_id2) REFERENCES t16 (id, id2)
+);
+INSERT INTO t12 VALUES (1), (2), (3);
+INSERT INTO t13 VALUES (4, 1), (5, 2);
+INSERT INTO t14 VALUES (6, 4);
+INSERT INTO t15 VALUES (1, 10), (2, 20), (3, 30);
+INSERT INTO t16 VALUES (4, 40, 1, 10), (5, 50, 2, 20);
+INSERT INTO t17 VALUES (6, 60, 4, 40);
+--
+-- Test nested foreign key joins
+--
+SELECT *
+FROM t12
+JOIN
+    t13 JOIN t14 KEY (b_id) -> t13 (id)
+KEY (a_id) -> t12 (id);
+ id | id | a_id | id | b_id 
+----+----+------+----+------
+  1 |  4 |    1 |  6 |    4
+(1 row)
+
+SELECT *
+FROM t12
+JOIN (t13 JOIN t14 KEY (b_id) -> t13 (id)) KEY (a_id) -> t12 (id);
+ id | id | a_id | id | b_id 
+----+----+------+----+------
+  1 |  4 |    1 |  6 |    4
+(1 row)
+
+--
+-- Test nested foreign key joins with composite foreign keys
+--
+SELECT *
+FROM t15
+JOIN
+    t16 JOIN t17 KEY (b_id, b_id2) -> t16 (id, id2)
+KEY (a_id, a_id2) -> t15 (id, id2);
+ id | id2 | id | id2 | a_id | a_id2 | id | id2 | b_id | b_id2 
+----+-----+----+-----+------+-------+----+-----+------+-------
+  1 |  10 |  4 |  40 |    1 |    10 |  6 |  60 |    4 |    40
+(1 row)
+
+--
+-- Explicit parenthesization:
+--
+SELECT *
+FROM t15
+JOIN
+(
+    t16 JOIN t17 KEY (b_id, b_id2) -> t16 (id, id2)
+) KEY (a_id, a_id2) -> t15 (id, id2);
+ id | id2 | id | id2 | a_id | a_id2 | id | id2 | b_id | b_id2 
+----+-----+----+-----+------+-------+----+-----+------+-------
+  1 |  10 |  4 |  40 |    1 |    10 |  6 |  60 |    4 |    40
+(1 row)
+
+--
+-- Test swapping the column order:
+--
+SELECT *
+FROM t15
+JOIN
+(
+    t16 JOIN t17 KEY (b_id, b_id2) -> t16 (id, id2)
+) KEY (a_id2, a_id) -> t15 (id2, id);
+ id | id2 | id | id2 | a_id | a_id2 | id | id2 | b_id | b_id2 
+----+-----+----+-----+------+-------+----+-----+------+-------
+  1 |  10 |  4 |  40 |    1 |    10 |  6 |  60 |    4 |    40
+(1 row)
+
+--
+-- Test mismatched column orders between referencing and referenced sides:
+--
+SELECT *
+FROM t15
+JOIN
+(
+    t16 JOIN t17 KEY (b_id, b_id2) -> t16 (id, id2)
+) KEY (a_id, a_id2) -> t15 (id2, id); -- error
+ERROR:  there is no foreign key constraint on table "<unnamed derived table>" (a_id, a_id2) referencing table "t15" (id2, id)
+LINE 6: ) KEY (a_id, a_id2) -> t15 (id2, id);
+          ^
+SELECT *
+FROM t15
+JOIN
+(
+    t16 JOIN t17 KEY (b_id, b_id2) -> t16 (id2, id)
+) KEY (a_id2, a_id) -> t15 (id2, id); -- error
+ERROR:  there is no foreign key constraint on table "t17" (b_id, b_id2) referencing table "t16" (id2, id)
+LINE 5:     t16 JOIN t17 KEY (b_id, b_id2) -> t16 (id2, id)
+                         ^
+--
+-- Test partitioned tables
+--
+CREATE TABLE pt2
+(
+    c3 int not null,
+    c4 int not null,
+    CONSTRAINT pt2_pkey PRIMARY KEY (c3),
+    CONSTRAINT pt2_c3_fkey FOREIGN KEY (c3) REFERENCES t1 (c1)
+) PARTITION BY RANGE (c3);
+CREATE TABLE pt2_1 PARTITION OF pt2 FOR VALUES FROM (1) TO (3);
+CREATE TABLE pt2_2 PARTITION OF pt2 FOR VALUES FROM (3) TO (4);
+CREATE TABLE pt3
+(
+    c5 int not null,
+    c6 int not null,
+    CONSTRAINT pt3_pkey PRIMARY KEY (c5),
+    CONSTRAINT pt3_c5_fkey FOREIGN KEY (c5) REFERENCES pt2 (c3)
+) PARTITION BY RANGE (c5);
+CREATE TABLE pt3_1 PARTITION OF pt3 FOR VALUES FROM (1) TO (3);
+CREATE TABLE pt3_2 PARTITION OF pt3 FOR VALUES FROM (3) TO (4);
+INSERT INTO pt2 (c3, c4) VALUES (1, 100);
+INSERT INTO pt2 (c3, c4) VALUES (3, 300);
+INSERT INTO pt3 (c5, c6) VALUES (1, 1000);
+INSERT INTO pt3 (c5, c6) VALUES (3, 3000);
+SELECT * FROM t1 JOIN pt2 KEY (c3) -> t1 (c1) JOIN pt3 KEY (c5) -> pt2 (c3);
+ c1 | c2 | c3 | c4  | c5 |  c6  
+----+----+----+-----+----+------
+  1 | 10 |  1 | 100 |  1 | 1000
+  3 | 30 |  3 | 300 |  3 | 3000
+(2 rows)
+
+SELECT * FROM t1 JOIN pt2_1 KEY (c3) -> t1 (c1);
+ c1 | c2 | c3 | c4  
+----+----+----+-----
+  1 | 10 |  1 | 100
+(1 row)
+
+DROP TABLE pt3;
+DROP TABLE pt2;

--- a/src/test/regress/expected/foreign_key_join.out
+++ b/src/test/regress/expected/foreign_key_join.out
@@ -1347,3 +1347,21 @@ SELECT * FROM t1 JOIN pt2_1 KEY (c3) -> t1 (c1);
 
 DROP TABLE pt3;
 DROP TABLE pt2;
+SELECT *
+FROM (SELECT * FROM (SELECT c1, c2 FROM t1) AS q1(q1_c1, q1_c2)) q
+JOIN t2 KEY (c3, c4) -> q (q1_c1, q1_c2);
+ q1_c1 | q1_c2 | c3 | c4
+-------+-------+----+----
+     1 |    10 |  1 | 10
+     3 |    30 |  3 | 30
+(2 rows)
+
+-- equivalent to:
+SELECT *
+FROM (WITH q1 (q1_c1, q1_c2) AS (SELECT c1, c2 FROM t1) SELECT * FROM q1) q
+JOIN t2 KEY (c3, c4) -> q (q1_c1, q1_c2);
+ q1_c1 | q1_c2 | c3 | c4
+-------+-------+----+----
+     1 |    10 |  1 | 10
+     3 |    30 |  3 | 30
+(2 rows)

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -119,7 +119,7 @@ test: plancache limit plpgsql copy2 temp domain rangefuncs prepare conversion tr
 # The stats test resets stats, so nothing else needing stats access can be in
 # this group.
 # ----------
-test: partition_join partition_prune reloptions hash_part indexing partition_aggregate partition_info tuplesort explain compression memoize stats predicate numa
+test: partition_join partition_prune reloptions hash_part indexing partition_aggregate partition_info tuplesort explain compression memoize stats predicate numa foreign_key_join
 
 # event_trigger depends on create_am and cannot run concurrently with
 # any test that runs DDL

--- a/src/test/regress/sql/foreign_key_join.sql
+++ b/src/test/regress/sql/foreign_key_join.sql
@@ -950,3 +950,11 @@ SELECT * FROM t1 JOIN pt2_1 KEY (c3) -> t1 (c1);
 
 DROP TABLE pt3;
 DROP TABLE pt2;
+
+SELECT *
+FROM (SELECT * FROM (SELECT c1, c2 FROM t1) AS q1(q1_c1, q1_c2)) q
+JOIN t2 KEY (c3, c4) -> q (q1_c1, q1_c2);
+-- equivalent to:
+SELECT *
+FROM (WITH q1 (q1_c1, q1_c2) AS (SELECT c1, c2 FROM t1) SELECT * FROM q1) q
+JOIN t2 KEY (c3, c4) -> q (q1_c1, q1_c2);

--- a/src/test/regress/sql/foreign_key_join.sql
+++ b/src/test/regress/sql/foreign_key_join.sql
@@ -1,0 +1,952 @@
+--
+-- Test Foreign Key Joins.
+--
+
+CREATE TABLE t1
+(
+    c1 int not null,
+    c2 int not null,
+    CONSTRAINT t1_pkey PRIMARY KEY (c1)
+);
+
+CREATE TABLE t2
+(
+    c3 int not null,
+    c4 int not null,
+    CONSTRAINT t2_pkey PRIMARY KEY (c3),
+    CONSTRAINT t2_c3_fkey FOREIGN KEY (c3) REFERENCES t1 (c1)
+);
+
+INSERT INTO t1 (c1, c2) VALUES (1, 10);
+INSERT INTO t1 (c1, c2) VALUES (2, 20);
+INSERT INTO t1 (c1, c2) VALUES (3, 30);
+INSERT INTO t2 (c3, c4) VALUES (1, 10);
+INSERT INTO t2 (c3, c4) VALUES (3, 30);
+
+--
+-- Test renaming tables and columns.
+--
+CREATE VIEW v1 AS
+SELECT *
+FROM t1
+JOIN t2 KEY (c3) -> t1 (c1);
+\d+ v1
+SELECT * FROM v1; -- ok
+
+ALTER TABLE t1 RENAME COLUMN c1 TO c1_renamed;
+ALTER TABLE t2 RENAME COLUMN c3 TO c3_renamed;
+ALTER TABLE t1 RENAME TO t1_renamed;
+ALTER TABLE t2 RENAME TO t2_renamed;
+\d+ v1
+
+SELECT * FROM v1; -- ok
+
+-- Undo the effect of the renames
+ALTER TABLE t2_renamed RENAME TO t2;
+ALTER TABLE t1_renamed RENAME TO t1;
+ALTER TABLE t2 RENAME COLUMN c3_renamed TO c3;
+ALTER TABLE t1 RENAME COLUMN c1_renamed TO c1;
+\d+ v1
+
+-- Test so we didn't break the parser
+SELECT 1<-2; -- ok, false
+
+SELECT * FROM v1; -- ok
+
+SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c1); -- ok
+SELECT * FROM t1 JOIN t2 KEY (c3) ->/*comment*/ t1 (c1); -- ok
+SELECT * FROM t1 JOIN t2 KEY (c3) /*comment*/-> t1 (c1); -- ok
+SELECT * FROM t1 JOIN t2 KEY (c3) /*comment*/->/*comment*/ t1 (c1); -- ok
+SELECT * FROM t1 JOIN t2 KEY (c3) - > t1 (c2); -- error
+SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c2); -- error
+SELECT * FROM t1 JOIN t2 KEY (c4) -> t1 (c1); -- error
+SELECT * FROM t1 JOIN t2 KEY (c3,c4) -> t1 (c1,c2); -- error
+SELECT * FROM t1 JOIN t2 KEY (c3) <- t1 (c1); -- error
+SELECT * FROM t1 JOIN t2 KEY (c1) <- t1 (c3); -- error
+SELECT * FROM t1 JOIN t2 KEY (c3) <- t1 (c2); -- error
+SELECT * FROM t1 JOIN t2 KEY (c4) <- t1 (c1); -- error
+SELECT * FROM t1 JOIN t2 KEY (c3,c4) <- t1 (c1,c2); -- error
+SELECT * FROM t1 AS a JOIN t2 AS b KEY (c3) -> a (c2); -- error
+
+SELECT * FROM t2 JOIN t1 KEY (c1) <- t2 (c3); -- ok
+SELECT * FROM t2 JOIN t1 KEY (c1) <-/*comment*/ t2 (c3); -- ok
+SELECT * FROM t2 JOIN t1 KEY (c1) /*comment*/<- t2 (c3); -- ok
+SELECT * FROM t2 JOIN t1 KEY (c1) /*comment*/<-/*comment*/ t2 (c3); -- ok
+SELECT * FROM t2 JOIN t1 KEY (c1) < - t2 (c3); -- error
+SELECT * FROM t2 JOIN t1 KEY (c1) <- t2 (c4); -- error
+SELECT * FROM t2 JOIN t1 KEY (c2) <- t2 (c3); -- error
+SELECT * FROM t2 JOIN t1 KEY (c1,c2) <- t2 (c3,c4); -- error
+SELECT * FROM t2 JOIN t1 KEY (c1) -> t2 (c3); -- error
+SELECT * FROM t2 JOIN t1 KEY (c1) -> t2 (c4); -- error
+SELECT * FROM t2 JOIN t1 KEY (c2) -> t2 (c3); -- error
+SELECT * FROM t2 JOIN t1 KEY (c1,c2) -> t2 (c3,c4); -- error
+SELECT * FROM t2 AS a JOIN t1 AS b KEY (c1) <- a (c4); -- error
+
+ALTER TABLE t2 DROP CONSTRAINT t2_c3_fkey; -- error
+
+DROP VIEW v1;
+ALTER TABLE t2 DROP CONSTRAINT t2_c3_fkey;
+
+SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c1); -- error
+SELECT * FROM t2 JOIN t1 KEY (c1) <- t2 (c3); -- error
+
+ALTER TABLE t1 ADD UNIQUE (c1,c2);
+ALTER TABLE t2 ADD CONSTRAINT t2_c3_c4_fkey FOREIGN KEY (c3,c4) REFERENCES t1 (c1,c2);
+
+CREATE VIEW v2 AS
+SELECT * FROM t1 JOIN t2 KEY (c3,c4) -> t1 (c1,c2); -- ok
+SELECT * FROM t1 JOIN t2 KEY (c3,c4) -> t1 (c1,c2); -- ok
+SELECT * FROM v2; -- ok
+\d+ v2
+
+CREATE VIEW v3 AS
+SELECT * FROM t2 JOIN t1 KEY (c1,c2) <- t2 (c3,c4); -- ok
+SELECT * FROM t2 JOIN t1 KEY (c1,c2) <- t2 (c3,c4); -- ok
+\d+ v3
+
+SELECT * FROM v3; -- ok
+
+SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c1); -- error
+SELECT * FROM t2 JOIN t1 KEY (c1) <- t2 (c3); -- error
+SELECT * FROM t1 JOIN t2 KEY (c3,c4) <- t1 (c1,c2); -- error
+SELECT * FROM t2 JOIN t1 KEY (c1,c2) -> t2 (c3,c4); -- error
+
+--
+-- Test nulls and multiple tables
+--
+
+CREATE TABLE t3
+(
+    c5 int,
+    c6 int,
+    CONSTRAINT t3_c5_c6_fkey FOREIGN KEY (c5, c6) REFERENCES t1 (c1, c2)
+);
+INSERT INTO t3 (c5, c6) VALUES (1, 10); -- ok
+INSERT INTO t3 (c5, c6) VALUES (3, 30); -- ok
+INSERT INTO t3 (c5, c6) VALUES (3, NULL); -- ok
+INSERT INTO t3 (c5, c6) VALUES (NULL, 30); -- ok
+INSERT INTO t3 (c5, c6) VALUES (1234, NULL); -- ok
+INSERT INTO t3 (c5, c6) VALUES (NULL, 5678); -- ok
+INSERT INTO t3 (c5, c6) VALUES (NULL, NULL); -- ok
+
+--
+-- Test composite foreign key joins with columns in matching order
+--
+SELECT *
+FROM t1
+JOIN t2 KEY (c3,c4) -> t1 (c1,c2)
+JOIN t3 KEY (c5,c6) -> t1 (c1,c2);
+
+SELECT *
+FROM t1
+JOIN t2 KEY (c3,c4) -> t1 (c1,c2)
+LEFT JOIN t3 KEY (c5,c6) -> t1 (c1,c2);
+
+SELECT *
+FROM t1
+JOIN t2 KEY (c3,c4) -> t1 (c1,c2)
+RIGHT JOIN t3 KEY (c5,c6) -> t1 (c1,c2);
+
+--
+-- Test composite foreign key joins with swapped column orders
+--
+SELECT *
+FROM t1
+JOIN t2 KEY (c4,c3) -> t1 (c2,c1)
+JOIN t3 KEY (c6,c5) -> t1 (c2,c1);
+
+--
+-- Test mismatched column orders between referencing and referenced sides
+--
+SELECT *
+FROM t1
+JOIN t2 KEY (c4,c3) -> t1 (c2,c1)
+JOIN t3 KEY (c6,c5) -> t1 (c1,c2); -- error
+
+--
+-- Test defining foreign key constraints with MATCH FULL
+--
+
+CREATE TABLE t4
+(
+    c7 int,
+    c8 int,
+    CONSTRAINT t4_c7_c8_fkey FOREIGN KEY (c7, c8) REFERENCES t1 (c1, c2) MATCH FULL
+);
+INSERT INTO t4 (c7, c8) VALUES (1, 10); -- ok
+INSERT INTO t4 (c7, c8) VALUES (3, 30); -- ok
+INSERT INTO t4 (c7, c8) VALUES (3, NULL); -- error
+INSERT INTO t4 (c7, c8) VALUES (NULL, 30); -- error
+INSERT INTO t4 (c7, c8) VALUES (1234, NULL); -- error
+INSERT INTO t4 (c7, c8) VALUES (NULL, 5678); -- error
+INSERT INTO t4 (c7, c8) VALUES (NULL, NULL); -- ok
+
+SELECT *
+FROM t1
+JOIN t2 KEY (c3,c4) -> t1 (c1,c2)
+JOIN t4 KEY (c7,c8) -> t1 (c1,c2);
+
+SELECT *
+FROM t1
+JOIN t2 KEY (c3,c4) -> t1 (c1,c2)
+LEFT JOIN t4 KEY (c7,c8) -> t1 (c1,c2);
+
+SELECT *
+FROM t1
+JOIN t2 KEY (c3,c4) -> t1 (c1,c2)
+RIGHT JOIN t4 KEY (c7,c8) -> t1 (c1,c2);
+
+-- Recrate stuff for pg_dump tests
+ALTER TABLE t2
+    ADD CONSTRAINT t2_c3_fkey FOREIGN KEY (c3) REFERENCES t1 (c1);
+CREATE VIEW v1 AS
+SELECT *
+FROM t1
+JOIN t2 KEY (c3) -> t1 (c1);
+
+CREATE TABLE t5
+(
+    c9 int not null,
+    c10 int not null,
+    c11 int not null,
+    c12 int not null,
+    CONSTRAINT t5_pkey PRIMARY KEY (c9, c10),
+    CONSTRAINT t5_c11_c12_fkey FOREIGN KEY (c11, c12) REFERENCES t1 (c1, c2)
+);
+
+INSERT INTO t5 (c9, c10, c11, c12) VALUES (1, 2, 1, 10);
+INSERT INTO t5 (c9, c10, c11, c12) VALUES (3, 4, 3, 30);
+
+CREATE TABLE t6
+(
+    c13 int not null,
+    c14 int not null,
+    CONSTRAINT t6_c13_c14_fkey FOREIGN KEY (c13, c14) REFERENCES t5 (c9, c10)
+);
+
+INSERT INTO t6 (c13, c14) VALUES (1, 2);
+INSERT INTO t6 (c13, c14) VALUES (3, 4);
+INSERT INTO t6 (c13, c14) VALUES (3, 4);
+
+CREATE TABLE t7
+(
+    c15 int not null,
+    c16 int not null,
+    CONSTRAINT t7_c15_c16_fkey FOREIGN KEY (c15, c16) REFERENCES t5 (c9, c10)
+);
+
+INSERT INTO t7 (c15, c16) VALUES (1, 2);
+INSERT INTO t7 (c15, c16) VALUES (1, 2);
+INSERT INTO t7 (c15, c16) VALUES (3, 4);
+
+CREATE TABLE t8
+(
+    c17 int not null,
+    c18 int not null,
+    c19 int,
+    c20 int,
+    CONSTRAINT t8_pkey PRIMARY KEY (c17, c18),
+    CONSTRAINT t8_c19_c20_fkey FOREIGN KEY (c19, c20) REFERENCES t1 (c1, c2)
+);
+
+INSERT INTO t8 (c17, c18, c19, c20) VALUES (1, 2, 1, 10);
+INSERT INTO t8 (c17, c18, c19, c20) VALUES (3, 4, 3, 30);
+
+CREATE TABLE t9
+(
+    c21 int not null,
+    c22 int not null,
+    CONSTRAINT t9_c21_c22_fkey FOREIGN KEY (c21, c22) REFERENCES t8 (c17, c18)
+);
+
+INSERT INTO t9 (c21, c22) VALUES (1, 2);
+INSERT INTO t9 (c21, c22) VALUES (3, 4);
+INSERT INTO t9 (c21, c22) VALUES (3, 4);
+
+CREATE TABLE t10
+(
+    c23 INT NOT NULL,
+    c24 INT NOT NULL,
+    c25 INT NOT NULL,
+    c26 INT NOT NULL,
+    CONSTRAINT t10_pkey PRIMARY KEY (c23, c24),
+    CONSTRAINT t10_c23_c24_fkey FOREIGN KEY (c23, c24) REFERENCES t1 (c1, c2),
+    CONSTRAINT t10_c25_c26_fkey FOREIGN KEY (c25, c26) REFERENCES t10 (c23, c24)
+);
+
+INSERT INTO t10 (c23, c24, c25, c26) VALUES (1, 10, 1, 10);
+
+CREATE TABLE t11
+(
+    c27 INT NOT NULL,
+    c28 INT NOT NULL,
+    CONSTRAINT t11_pkey PRIMARY KEY (c27, c28),
+    CONSTRAINT t11_c27_c28_fkey FOREIGN KEY (c27, c28) REFERENCES t10 (c23, c24)
+);
+
+INSERT INTO t11 (c27, c28) VALUES (1, 10);
+
+--
+-- Test subqueries
+--
+
+SELECT
+    a.c1,
+    a.c2,
+    b.c3,
+    b.c4
+FROM t1 AS a
+JOIN
+(
+    SELECT * FROM t2
+) AS b KEY (c3) -> a (c1);
+
+SELECT
+    a.c1,
+    a.c2,
+    b.c3,
+    b.c4
+FROM
+(
+    SELECT * FROM t1
+) AS a
+JOIN
+(
+    SELECT * FROM t2
+) AS b KEY (c3) -> a (c1);
+
+SELECT
+    a.t1_c1,
+    a.t1_c2,
+    b.t2_c3,
+    b.t2_c4
+FROM
+(
+    SELECT c1 AS t1_c1, c2 AS t1_c2 FROM t1
+) AS a
+JOIN
+(
+    SELECT c3 AS t2_c3, c4 AS t2_c4 FROM t2
+) AS b KEY (t2_c3) -> a (t1_c1);
+
+SELECT
+    a.outer_c1,
+    a.outer_c2,
+    b.outer_c3,
+    b.outer_c4
+FROM
+(
+    SELECT mid_c1 AS outer_c1, mid_c2 AS outer_c2 FROM
+    (
+        SELECT c1 AS mid_c1, c2 AS mid_c2 FROM t1
+    ) sub1
+) AS a
+JOIN
+(
+    SELECT mid_c3 AS outer_c3, mid_c4 AS outer_c4 FROM
+    (
+        SELECT c3 AS mid_c3, c4 AS mid_c4 FROM t2
+    ) sub2
+) AS b KEY (outer_c3) -> a (outer_c1);
+
+SELECT *
+FROM t1
+JOIN
+(
+    SELECT
+        t10.c23,
+        t10.c24,
+        t10_2.c25,
+        t10_2.c26
+    FROM t10
+    JOIN t10 AS t10_2 KEY (c23, c24) <- t10 (c25, c26)
+) AS q1 KEY (c23, c24) -> t1 (c1, c2);
+
+SELECT *
+FROM t1
+JOIN LATERAL (
+    SELECT c3, c4 FROM t2 WHERE c4 = c1 + 9
+) AS q1 KEY (c3) -> t1 (c1);
+
+--
+-- Test CTEs
+--
+
+WITH
+q1 (q1_c1, q1_c2) AS
+(
+    SELECT c1, c2 FROM t1
+),
+q2 (q2_c1, q2_c2) AS
+(
+    SELECT q1_c1, q1_c2 FROM q1
+),
+q3 (q3_c3, q3_c4) AS
+(
+    SELECT c3, c4 FROM t2
+),
+q4 (q4_c3, q4_c4) AS
+(
+    SELECT q3_c3, q3_c4 FROM q3
+)
+SELECT
+    q2_c1,
+    q2_c2,
+    q4_c3,
+    q4_c4
+FROM q2 JOIN q4 KEY (q4_c3, q4_c4) -> q2 (q2_c1, q2_c2);
+
+WITH RECURSIVE q1 AS (SELECT c1 FROM t1 UNION SELECT c1 FROM q1)
+SELECT * FROM q1 JOIN t2 KEY (c3) -> q1 (c1);
+
+--
+-- Test VIEWs
+--
+
+DROP VIEW v1, v2, v3;
+
+CREATE VIEW v1 AS
+SELECT c1 AS v1_c1, c2 AS v1_c2 FROM t1;
+
+CREATE VIEW v2 AS
+SELECT v1_c1 AS v2_c1, v1_c2 AS v2_c2 FROM v1;
+
+CREATE VIEW v3 AS
+SELECT c3 AS v3_c3, c4 AS v3_c4 FROM t2;
+
+CREATE VIEW v4 AS
+SELECT v3_c3 AS v4_c3, v3_c4 AS v4_c4 FROM v3;
+
+CREATE VIEW v5 AS
+SELECT
+    v2_c1,
+    v2_c2,
+    v4_c3,
+    v4_c4
+FROM v2 JOIN v4 KEY (v4_c3, v4_c4) -> v2 (v2_c1, v2_c2);
+
+SELECT * FROM v5;
+
+--
+-- Test subqueries, CTEs, and views
+--
+WITH
+q2 (q2_c1, q2_c2) AS
+(
+    SELECT
+        q1_c1,
+        q1_c2
+    FROM
+    (
+        SELECT c1 AS q1_c1, c2 AS q1_c2 FROM t1
+    ) AS q1
+)
+SELECT
+    q2_c1,
+    q2_c2,
+    v4_c3,
+    v4_c4
+FROM q2 JOIN v4 KEY (v4_c3, v4_c4) -> q2 (q2_c1, q2_c2);
+
+DROP VIEW v1, v2, v3, v4, v5;
+
+--
+-- Test subqueries, CTEs and VIEWs containing joins
+--
+
+SELECT
+    q1.c11,
+    q1.c12,
+    t6.c13,
+    t6.c14
+FROM
+(
+    SELECT
+        t5.c9,
+        t5.c10,
+        t5.c11,
+        t5.c12
+    FROM t5
+    JOIN t1 KEY (c1, c2) <- t5 (c11, c12)
+    JOIN t1 AS t1_2 KEY (c1, c2) <- t5 (c11, c12)
+    JOIN t1 AS t1_3 KEY (c1, c2) <- t5 (c11, c12)
+) AS q1
+JOIN t6 KEY (c13, c14) -> q1 (c9, c10);
+
+WITH
+q1 AS
+(
+    SELECT
+        t5.c9,
+        t5.c10,
+        t5.c11,
+        t5.c12
+    FROM t5
+    JOIN t1 KEY (c1, c2) <- t5 (c11, c12)
+    JOIN t1 AS t1_2 KEY (c1, c2) <- t5 (c11, c12)
+    JOIN t1 AS t1_3 KEY (c1, c2) <- t5 (c11, c12)
+)
+SELECT
+    q1.c11,
+    q1.c12,
+    t6.c13,
+    t6.c14
+FROM q1
+JOIN t6 KEY (c13, c14) -> q1 (c9, c10);
+
+CREATE VIEW v1 AS
+SELECT
+    t5.c9,
+    t5.c10,
+    t5.c11,
+    t5.c12
+FROM t5
+JOIN t1 KEY (c1, c2) <- t5 (c11, c12)
+JOIN t1 AS t1_2 KEY (c1, c2) <- t5 (c11, c12)
+JOIN t1 AS t1_3 KEY (c1, c2) <- t5 (c11, c12);
+
+SELECT
+    v1.c11,
+    v1.c12,
+    t6.c13,
+    t6.c14
+FROM v1
+JOIN t6 KEY (c13, c14) -> v1 (c9, c10);
+
+DROP VIEW v1;
+
+--
+-- Test disallowed filtering of referenced table
+--
+
+CREATE VIEW v1 AS
+SELECT * FROM t1 WHERE c1 > 0;
+
+CREATE VIEW v2 AS
+SELECT * FROM t2 WHERE c3 > 0;
+
+-- invalid since v1 is filtered and is the referenced table
+SELECT * FROM v1 JOIN t2 KEY (c3) -> v1 (c1);
+
+-- OK, filtering allowed since v2 is the referencing table
+SELECT * FROM t1 JOIN v2 KEY (c3) -> t1 (c1);
+
+-- also invalid, since v1 is filtered and is the referenced table
+SELECT * FROM v1 JOIN v2 KEY (c3) -> v1 (c1);
+
+-- also invalid, filters uisng a having clause
+SELECT * FROM
+(
+    SELECT c1, count(*) FROM t1 GROUP BY c1 HAVING c2 > 100
+) AS u
+JOIN t2 KEY (c3) -> u (c1);
+
+-- invalid, since u is filtered and is the referenced table
+SELECT * FROM (SELECT c1 FROM t1 LIMIT 1) AS u
+JOIN t2 KEY (c3) -> u (c1);
+
+-- invalid, since u is filtered and is the referenced table
+SELECT * FROM (SELECT c1 FROM t1 OFFSET 1) AS u
+JOIN t2 KEY (c3) -> u (c1);
+
+-- invalid, since referenced table has RLS enabled
+ALTER TABLE t1 ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY t1_policy ON t1 USING (false);
+
+SELECT * FROM (SELECT c1 FROM t1) AS u
+JOIN t2 KEY (c3) -> u (c1);
+
+SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c1);
+
+ALTER TABLE t1 DISABLE ROW LEVEL SECURITY;
+
+WITH q2 AS
+(
+    SELECT * FROM t5 WHERE t5.c11 > 0
+)
+SELECT
+    q1.c11,
+    q1.c12,
+    t7.c15,
+    t7.c16
+FROM
+(
+    SELECT
+        q2.c9,
+        q2.c10,
+        q2.c11,
+        q2.c12
+    FROM q2
+    JOIN t1 KEY (c1, c2) <- q2 (c11, c12)
+) AS q1
+JOIN t7 KEY (c15, c16) -> q1 (c9, c10);
+
+--
+-- Test allowed joins not affecting uniqueness
+--
+
+SELECT
+    q1.c11,
+    q1.c12,
+    t6.c13,
+    t6.c14
+FROM
+(
+    SELECT
+        t5.c9,
+        t5.c10,
+        t5.c11,
+        t5.c12
+    FROM t5
+    JOIN t1 KEY (c1, c2) <- t5 (c11, c12)
+) AS q1
+JOIN t6 KEY (c13, c14) -> q1 (c9, c10);
+
+--
+-- Test disallowed non-unique referenced table
+--
+
+SELECT
+    q1.c11,
+    q1.c12,
+    t7.c15,
+    t7.c16
+FROM
+(
+    SELECT
+        t5.c9,
+        t5.c10,
+        t5.c11,
+        t5.c12
+    FROM t5
+    JOIN t1 KEY (c1, c2) <- t5 (c11, c12)
+    JOIN t6 KEY (c13, c14) -> t5 (c9, c10)
+) AS q1
+JOIN t7 KEY (c15, c16) -> q1 (c9, c10);
+
+SELECT
+    q1.c19,
+    q1.c20,
+    t9.c21,
+    t9.c22
+FROM
+(
+    SELECT
+        t8.c17,
+        t8.c18,
+        t8.c19,
+        t8.c20
+    FROM t8
+    JOIN t1 KEY (c1, c2) <- t8 (c19, c20)
+) AS q1
+JOIN t9 KEY (c21, c22) -> q1 (c17, c18);
+
+--
+-- Test revalidation of views
+--
+
+CREATE TABLE addresses
+(
+    id           INTEGER      NOT NULL,
+    street       VARCHAR(255) NOT NULL,
+    city         VARCHAR(100) NOT NULL,
+    state        VARCHAR(100) NOT NULL,
+    country_code CHAR(2)      NOT NULL,
+    zip_code     VARCHAR(20)  NOT NULL,
+    CONSTRAINT addresses_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE customers
+(
+    id         INTEGER      NOT NULL,
+    name       VARCHAR(255) NOT NULL,
+    address_id INTEGER      NOT NULL,
+    CONSTRAINT customers_pkey            PRIMARY KEY (id),
+    CONSTRAINT customers_address_id_fkey FOREIGN KEY (address_id) REFERENCES addresses (id)
+);
+
+CREATE TABLE orders
+(
+    id           BIGINT         NOT NULL,
+    order_date   DATE           NOT NULL,
+    amount       DECIMAL(10, 2) NOT NULL,
+    customer_id  INTEGER        NOT NULL,
+    CONSTRAINT orders_pkey             PRIMARY KEY (id),
+    CONSTRAINT orders_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES customers (id)
+);
+
+CREATE VIEW customer_details AS
+SELECT
+    c.id AS customer_id,
+    c.name AS customer_name,
+    a.street,
+    a.city,
+    a.state,
+    a.country_code,
+    a.zip_code
+FROM customers AS c
+JOIN addresses AS a KEY (id) <- c (address_id);
+
+CREATE VIEW orders_by_country AS
+SELECT
+    cd.country_code,
+    COUNT(*) AS order_count,
+    SUM(o.amount) AS total_amount
+FROM orders AS o
+JOIN customer_details AS cd KEY (customer_id) <- o (customer_id)
+GROUP BY ROLLUP (cd.country_code);
+
+CREATE TABLE customer_addresses
+(
+    customer_id INTEGER NOT NULL,
+    address_id INTEGER NOT NULL,
+    CONSTRAINT customer_addresses_pkey             PRIMARY KEY (customer_id, address_id),
+    CONSTRAINT customer_addresses_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES customers (id),
+    CONSTRAINT customer_addresses_address_id_fkey  FOREIGN KEY (address_id) REFERENCES addresses (id)
+);
+
+-- error, since it would invalidate foreign key join in orders_by_country
+-- that uses customer_details
+CREATE OR REPLACE VIEW customer_details AS
+SELECT
+    c.id AS customer_id,
+    c.name AS customer_name,
+    a.street,
+    a.city,
+    a.state,
+    a.country_code,
+    a.zip_code
+FROM customers AS c
+JOIN customer_addresses AS ca KEY (customer_id) -> c (id)
+JOIN addresses AS a KEY (id) <- ca (address_id);
+
+--
+-- Test various error conditions
+--
+
+SELECT * FROM t1 JOIN t2 KEY (c3, c4) -> t3 (c1, c2);
+
+SELECT * FROM t1 JOIN t2 KEY (c3, c4) -> t1 (c1);
+SELECT * FROM t1 JOIN t2 KEY (c3) -> t1 (c1, c2);
+SELECT * FROM t1 JOIN t2 KEY (c3, c4) -> t1 (c1, c2, c3);
+SELECT * FROM t1 JOIN t2 KEY (c3, c4, c5) -> t1 (c1, c2);
+
+CREATE FUNCTION t2() RETURNS TABLE (c3 INTEGER, c4 INTEGER)
+LANGUAGE sql
+BEGIN ATOMIC
+    SELECT 1, 2;
+END;
+SELECT * FROM t1 JOIN t2() KEY (c3, c4) -> t1 (c1, c2);
+
+SELECT * FROM t1 JOIN t2 KEY (c3, c4) -> t1 (c1, c5);
+
+DROP VIEW v1, v2;
+CREATE VIEW v1 AS SELECT c1 AS c1_1, c1 AS c1_2, c2 AS c2_1, c2 AS c2_2 FROM t1;
+CREATE VIEW v2 AS SELECT c3 AS c3_1, c3 AS c3_2, c4 AS c4_1, c4 AS c4_2 FROM t2;
+
+SELECT * FROM v1 JOIN t2 KEY (c3, c4) -> v1 (c1_1, c2_1); -- ok
+
+SELECT * FROM v1 JOIN t2 KEY (c3, c4) -> v1 (c1_1, c1_2);
+
+SELECT * FROM v1 JOIN t2 KEY (c3, c4) -> v1 (c1_1, nonexistent);
+
+/*
+ * We don't need to check for duplicate columns,
+ * since there is already such a check for foreign key constraints.
+ */
+SELECT * FROM v1 JOIN t2 KEY (c3, c3) -> v1 (c1_1, c1_1);
+
+DROP VIEW v1;
+CREATE VIEW v1 AS SELECT c1+0 AS c1_1, c1 AS c1_2, c2 AS c2_1, c2 AS c2_2 FROM t1;
+SELECT * FROM v1 JOIN t2 KEY (c3, c4) -> v1 (c1_1, c2_1);
+
+SELECT * FROM t1 JOIN
+(
+    SELECT c3, c4 FROM t2
+    UNION ALL
+    SELECT c3, c4 FROM t2
+) AS u KEY (c3, c4) -> t1 (c1, c2);
+
+SELECT * FROM
+(
+    SELECT c1, c2 FROM t1 WHERE c2 > 0
+) AS u
+JOIN t2 KEY (c3, c4) -> u (c1, c2);
+
+SELECT *
+FROM t1
+JOIN
+(
+    SELECT * FROM t10
+    JOIN t10 AS t10_2 KEY (c23, c24) <- t10 (c25, c26)
+) AS q1 KEY (c23, c24) -> t1 (c1, c2);
+
+SELECT *
+FROM t1
+JOIN
+(
+    SELECT
+        t10.c23,
+        t10.c24,
+        t10_2.c25,
+        t10_2.c26
+    FROM t10
+    JOIN t10 AS t10_2 KEY (c23, c24) <- t10 (c25, c26)
+) AS q1 KEY (nonexistent, c24) -> t1 (c1, c2);
+
+SELECT *
+FROM t1
+JOIN
+(
+    SELECT
+        t10.c23,
+        t10_2.c24
+    FROM t10
+    JOIN t10 AS t10_2 KEY (c23, c24) <- t10 (c25, c26)
+) AS q1 KEY (c23, c24) -> t1 (c1, c2);
+
+--
+-- Test materialized views (not supported)
+--
+
+CREATE MATERIALIZED VIEW mv1 AS
+SELECT c1, c2 FROM t1;
+
+SELECT * FROM mv1 JOIN t2 KEY (c3, c4) -> mv1 (c1, c2);
+
+DROP MATERIALIZED VIEW mv1;
+
+--
+-- Test nested foreign keyjoins
+--
+CREATE TABLE t12 (id integer PRIMARY KEY);
+CREATE TABLE t13 (id integer PRIMARY KEY, a_id integer REFERENCES t12(id));
+CREATE TABLE t14 (id integer PRIMARY KEY, b_id integer REFERENCES t13(id));
+
+CREATE TABLE t15 (
+    id integer,
+    id2 integer,
+    PRIMARY KEY (id, id2)
+);
+CREATE TABLE t16 (
+    id integer,
+    id2 integer,
+    a_id integer,
+    a_id2 integer,
+    PRIMARY KEY (id, id2),
+    FOREIGN KEY (a_id, a_id2) REFERENCES t15 (id, id2)
+);
+CREATE TABLE t17 (
+    id integer,
+    id2 integer,
+    b_id integer,
+    b_id2 integer,
+    PRIMARY KEY (id, id2),
+    FOREIGN KEY (b_id, b_id2) REFERENCES t16 (id, id2)
+);
+
+INSERT INTO t12 VALUES (1), (2), (3);
+INSERT INTO t13 VALUES (4, 1), (5, 2);
+INSERT INTO t14 VALUES (6, 4);
+INSERT INTO t15 VALUES (1, 10), (2, 20), (3, 30);
+INSERT INTO t16 VALUES (4, 40, 1, 10), (5, 50, 2, 20);
+INSERT INTO t17 VALUES (6, 60, 4, 40);
+
+--
+-- Test nested foreign key joins
+--
+SELECT *
+FROM t12
+JOIN
+    t13 JOIN t14 KEY (b_id) -> t13 (id)
+KEY (a_id) -> t12 (id);
+
+SELECT *
+FROM t12
+JOIN (t13 JOIN t14 KEY (b_id) -> t13 (id)) KEY (a_id) -> t12 (id);
+
+--
+-- Test nested foreign key joins with composite foreign keys
+--
+SELECT *
+FROM t15
+JOIN
+    t16 JOIN t17 KEY (b_id, b_id2) -> t16 (id, id2)
+KEY (a_id, a_id2) -> t15 (id, id2);
+
+--
+-- Explicit parenthesization:
+--
+SELECT *
+FROM t15
+JOIN
+(
+    t16 JOIN t17 KEY (b_id, b_id2) -> t16 (id, id2)
+) KEY (a_id, a_id2) -> t15 (id, id2);
+
+--
+-- Test swapping the column order:
+--
+
+SELECT *
+FROM t15
+JOIN
+(
+    t16 JOIN t17 KEY (b_id, b_id2) -> t16 (id, id2)
+) KEY (a_id2, a_id) -> t15 (id2, id);
+
+--
+-- Test mismatched column orders between referencing and referenced sides:
+--
+
+SELECT *
+FROM t15
+JOIN
+(
+    t16 JOIN t17 KEY (b_id, b_id2) -> t16 (id, id2)
+) KEY (a_id, a_id2) -> t15 (id2, id); -- error
+
+SELECT *
+FROM t15
+JOIN
+(
+    t16 JOIN t17 KEY (b_id, b_id2) -> t16 (id2, id)
+) KEY (a_id2, a_id) -> t15 (id2, id); -- error
+
+--
+-- Test partitioned tables
+--
+
+CREATE TABLE pt2
+(
+    c3 int not null,
+    c4 int not null,
+    CONSTRAINT pt2_pkey PRIMARY KEY (c3),
+    CONSTRAINT pt2_c3_fkey FOREIGN KEY (c3) REFERENCES t1 (c1)
+) PARTITION BY RANGE (c3);
+
+CREATE TABLE pt2_1 PARTITION OF pt2 FOR VALUES FROM (1) TO (3);
+CREATE TABLE pt2_2 PARTITION OF pt2 FOR VALUES FROM (3) TO (4);
+
+CREATE TABLE pt3
+(
+    c5 int not null,
+    c6 int not null,
+    CONSTRAINT pt3_pkey PRIMARY KEY (c5),
+    CONSTRAINT pt3_c5_fkey FOREIGN KEY (c5) REFERENCES pt2 (c3)
+) PARTITION BY RANGE (c5);
+
+CREATE TABLE pt3_1 PARTITION OF pt3 FOR VALUES FROM (1) TO (3);
+CREATE TABLE pt3_2 PARTITION OF pt3 FOR VALUES FROM (3) TO (4);
+
+INSERT INTO pt2 (c3, c4) VALUES (1, 100);
+INSERT INTO pt2 (c3, c4) VALUES (3, 300);
+INSERT INTO pt3 (c5, c6) VALUES (1, 1000);
+INSERT INTO pt3 (c5, c6) VALUES (3, 3000);
+
+SELECT * FROM t1 JOIN pt2 KEY (c3) -> t1 (c1) JOIN pt3 KEY (c5) -> pt2 (c3);
+SELECT * FROM t1 JOIN pt2_1 KEY (c3) -> t1 (c1);
+
+DROP TABLE pt3;
+DROP TABLE pt2;

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -836,6 +836,9 @@ ForeignAsyncNotify_function
 ForeignAsyncRequest_function
 ForeignDataWrapper
 ForeignKeyCacheInfo
+ForeignKeyClause
+ForeignKeyDirection
+ForeignKeyJoinNode
 ForeignKeyOptInfo
 ForeignPath
 ForeignScan
@@ -2390,6 +2393,7 @@ RI_CompareKey
 RI_ConstraintInfo
 RI_QueryHashEntry
 RI_QueryKey
+RTEId
 RTEKind
 RTEPermissionInfo
 RWConflict


### PR DESCRIPTION
## Summary
- ensure drill_down_to_base_rel can look up CTEs defined inside subqueries
- thread the Query pointer through recursive calls when descending through joins

## Testing
- `git status --short`